### PR TITLE
Changed exception handling in AzureServicebusSubscriptionNotifier to catchch more generic MessagingException.

### DIFF
--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus/Receiving/AzureServiceBusQueueNotifier.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus/Receiving/AzureServiceBusQueueNotifier.cs
@@ -84,7 +84,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
 
                 Thread.Sleep(TimeSpan.FromSeconds(BackoffTimeInSeconds));
             }
-            catch (MessagingCommunicationException)
+            catch (MessagingException)
             {
                 if (cancelRequested) return;
 

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus/Receiving/AzureServiceBusSubscriptionNotifier.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus/Receiving/AzureServiceBusSubscriptionNotifier.cs
@@ -87,7 +87,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
 
                 Thread.Sleep(TimeSpan.FromSeconds(BackoffTimeInSeconds));
             }
-            catch (MessagingCommunicationException)
+            catch (MessagingException)
             {
                 if (cancelRequested) return;
 


### PR DESCRIPTION
In some situations, azure servicebus throws an exception that get's wrapped in a MessagingException, not in the MessagingCommuncationException.  Since these exceptions would then be unhandled, the worker process grinds to a halt.
