### PR TITLE
Test successful invocation of AzureMessageQueueUtils with expected results

### DIFF
--- a/ripple.config
+++ b/ripple.config
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ripple xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ripple xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>NServiceBus.Azure</Name>
   <NugetSpecFolder>packaging/nuget</NugetSpecFolder>
   <SourceFolder>src</SourceFolder>

--- a/src/NServiceBus.Azure.QuickTests/Transports/AzureStorage/When_naming_queues_on_azure_storage.cs
+++ b/src/NServiceBus.Azure.QuickTests/Transports/AzureStorage/When_naming_queues_on_azure_storage.cs
@@ -10,15 +10,15 @@
     {
         Address address;
 
-        [TestCase("TestQueue")]
-        [TestCase("Test.Queue")]
-        [TestCase("TestQueueTestQueueTestQueueTestQueueTestQueueTestQueueTestQueue")]
-        [TestCase("Test1234Queue")]
-        public void Should_fix_queue_name_when_upper_case_letters_are_used_dots_or_longer_than_63_charachters(string queueName)
+        [TestCase("TestQueue", "testqueue")]
+        [TestCase("Test.Queue", "test-queue")]
+        [TestCase("Test1234Queue", "test1234queue")]
+        [TestCase("TestQueueTestQueueTestQueueTestQueueTestQueueTestQueueTestQueueTestQueue", "testqueuetestqueuetestqueu-7565a1c3-1977-44ef-1a56-65be23eb5232")]
+        public void Should_fix_queue_name_when_upper_case_letters_are_used_dots_or_longer_than_63_charachters(string queueName, string expectedQueueName)
         {
             address = new Address(queueName, "UseDevelopmentStorage=true");
 
-            Assert.DoesNotThrow(() => AzureMessageQueueUtils.GetQueueName(address));
+            Assert.AreEqual(expectedQueueName, AzureMessageQueueUtils.GetQueueName(address));
         }
 
         [TestCase("Test_Queue")]


### PR DESCRIPTION
Addresses [issues/164](https://github.com/Particular/NServiceBus.Azure/issues/164).
Added expected result to test against. Updated input queue name to test a case when a queue name is longer than 64 characters. 
@yvesgoeleven, please review.
