### PR TITLE
fix TimeSpan.MaxValue bug

### DIFF
--- a/src/NServiceBus.Azure/DataBus/Azure/BlobStorage/BlobStorageDataBus.cs
+++ b/src/NServiceBus.Azure/DataBus/Azure/BlobStorage/BlobStorageDataBus.cs
@@ -39,14 +39,7 @@ namespace NServiceBus.DataBus.Azure.BlobStorage
         {
             var key = Guid.NewGuid().ToString();
             var blob = container.GetBlockBlobReference(Path.Combine(BasePath, key));
-            if (timeToBeReceived != TimeSpan.MaxValue)
-            {
-                blob.Metadata["ValidUntil"] = (DateTime.UtcNow + timeToBeReceived).ToString();
-            }
-            else
-            {
-                blob.Metadata["ValidUntil"] = TimeSpan.MaxValue.ToString();
-            }
+	        blob.Metadata["ValidUntil"] = (timeToBeReceived == TimeSpan.MaxValue ? DateTime.MaxValue : DateTime.UtcNow + timeToBeReceived).ToString();
             blob.Metadata["ValidUntilKind"] = "Utc";
             UploadBlobInParallel(blob, stream);
             return key;


### PR DESCRIPTION
TimeSpan.MaxValue.ToString() = 10675199.02:48:05.4775807

That produces wildly unpredictable results and the blob storage container winds up culling records it should not.

Using DateTime.MaxValue solves that by outputting 12/31/9999 11:59:59 PM instead
