### PR TITLE
[WIP] Hotfix 5.3.12 - Prevent timeout message loss when not using DTC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ _NCrunch_NServiceBus/*
 logs
 run-git.cmd
 src/Chocolatey/Build/*
-App_Packages

--- a/ripple.config
+++ b/ripple.config
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ripple xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ripple xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>NServiceBus.Azure</Name>
   <NugetSpecFolder>packaging/nuget</NugetSpecFolder>
   <SourceFolder>src</SourceFolder>

--- a/ripple.config
+++ b/ripple.config
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ripple xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<ripple xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>NServiceBus.Azure</Name>
   <NugetSpecFolder>packaging/nuget</NugetSpecFolder>
   <SourceFolder>src</SourceFolder>
@@ -8,8 +8,8 @@
   <DefaultFloatConstraint>Current,NextMajor</DefaultFloatConstraint>
   <DefaultFixedConstraint>Current,NextMajor</DefaultFixedConstraint>
   <Feeds>
-    <Feed Url="https://www.myget.org/F/particular/" Mode="Fixed" Stability="Anything" StabilityConvention="GitFlow" />
     <Feed Url="http://nuget.org/api/v2" Mode="Fixed" Stability="ReleasedOnly" StabilityConvention="None" />
+    <Feed Url="https://www.myget.org/F/particular/" Mode="Fixed" Stability="ReleasedOnly" StabilityConvention="None" />
   </Feeds>
   <Nugets>
     <Dependency Name="Autofac" Version="3.0.0.0" Mode="Fixed" />
@@ -26,10 +26,10 @@
     <Dependency Name="Microsoft.WindowsAzure.ConfigurationManager" Version="2.0.1.0" Mode="Fixed" />
     <Dependency Name="Newtonsoft.Json" Version="5.0.6" Mode="Fixed" />
     <Dependency Name="NLog" Version="2.0.1.2" Mode="Fixed" />
-    <Dependency Name="NServiceBus" Version="4.6.6.0" Mode="Fixed" />
-    <Dependency Name="NServiceBus.AcceptanceTesting" Version="4.6.6.0" Mode="Fixed" />
-    <Dependency Name="NServiceBus.AcceptanceTests.Sources" Version="4.6.6.0" Mode="Fixed" />
-    <Dependency Name="NServiceBus.Interfaces" Version="4.6.6.0" Mode="Fixed" />
+    <Dependency Name="NServiceBus" Version="4.6.10" Mode="Fixed" />
+    <Dependency Name="NServiceBus.AcceptanceTesting" Version="4.6.10" Mode="Fixed" />
+    <Dependency Name="NServiceBus.AcceptanceTests.Sources" Version="4.6.10" Mode="Fixed" />
+    <Dependency Name="NServiceBus.Interfaces" Version="4.6.10" Mode="Fixed" />
     <Dependency Name="NUnit" Version="2.6.3" Mode="Fixed" />
     <Dependency Name="Obsolete.Fody" Version="3.0.4.0" Mode="Fixed" />
     <Dependency Name="RavenDB.Client" Version="2.0.2375.0" Mode="Fixed" />

--- a/ripple.config
+++ b/ripple.config
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ripple xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<ripple xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>NServiceBus.Azure</Name>
   <NugetSpecFolder>packaging/nuget</NugetSpecFolder>
   <SourceFolder>src</SourceFolder>

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
@@ -1,0 +1,130 @@
+﻿namespace NServiceBus.AcceptanceTests.Audit
+{
+    using System;
+    using System.Linq;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+
+    public class When_a_message_is_audited : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_preserve_the_original_body()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                    .WithEndpoint<AuditSpyEndpoint>()
+                    .Done(c => c.AuditChecksum != default(byte))
+                    .Run();
+
+            Assert.AreEqual(context.OriginalBodyChecksum, context.AuditChecksum, "The body of the message sent to audit should be the same as the original message coming off the queue");
+        }
+
+        [Test]
+        public void Should_add_the_license_diagnostic_headers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                    .WithEndpoint<AuditSpyEndpoint>()
+                    .Done(c => c.HasDiagnosticLicensingHeaders)
+                    .Run();
+            Assert.IsTrue(context.HasDiagnosticLicensingHeaders);
+        }
+
+
+        public class Context : ScenarioContext
+        {
+            public byte OriginalBodyChecksum { get; set; }
+            public byte AuditChecksum { get; set; }
+            public bool HasDiagnosticLicensingHeaders { get; set; }
+        }
+
+        public class EndpointWithAuditOn : EndpointConfigurationBuilder
+        {
+            public EndpointWithAuditOn()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<AuditSpyEndpoint>();
+            }
+
+            class BodyMutator : IMutateIncomingTransportMessages, INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+
+                    var originalBody = transportMessage.Body;
+
+                    Context.OriginalBodyChecksum = Checksum(originalBody);
+
+                    // modifying the body by adding a line break
+                    var modifiedBody = new byte[originalBody.Length + 1];
+
+                    Buffer.BlockCopy(originalBody, 0, modifiedBody, 0, originalBody.Length);
+
+                    modifiedBody[modifiedBody.Length - 1] = 13;
+
+                    transportMessage.Body = modifiedBody;
+                }
+
+                public void Init()
+                {
+                    Configure.Component<BodyMutator>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited> { public void Handle(MessageToBeAudited message) { } }
+        }
+
+        class AuditSpyEndpoint : EndpointConfigurationBuilder
+        {
+            public AuditSpyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class BodySpy : IMutateIncomingTransportMessages, INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    Context.AuditChecksum = Checksum(transportMessage.Body);
+                    string licenseExpired;
+                    Context.HasDiagnosticLicensingHeaders = transportMessage.Headers.TryGetValue(Headers.HasLicenseExpired, out licenseExpired);
+                }
+
+                public void Init()
+                {
+                    Configure.Component<BodySpy>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited> { public void Handle(MessageToBeAudited message) { } }
+        }
+
+        public static byte Checksum(byte[] data)
+        {
+            var longSum = data.Sum(x => (long)x);
+            return unchecked((byte)longSum);
+        }
+
+        [Serializable]
+        public class MessageToBeAudited : IMessage
+        {
+        }
+
+        
+    }
+
+#pragma warning restore  612, 618
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Audit/When_using_auditing_as_a_feature.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Audit/When_using_auditing_as_a_feature.cs
@@ -1,0 +1,111 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Audit
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_using_auditing_as_a_feature : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_not_be_forwarded_to_auditQueue_when_auditing_is_disabled()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+            .WithEndpoint<EndpointWithAuditOff>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+            .WithEndpoint<EndpointThatHandlesAuditMessages>()
+            .Done(c => c.IsMessageHandlingComplete)
+            .Run();
+
+            Assert.IsFalse(context.IsMessageHandledByTheAuditEndpoint);
+        }
+
+        [Test]
+        public void Message_should_be_forwarded_to_auditQueue_when_auditing_is_enabled()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+            .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+            .WithEndpoint<EndpointThatHandlesAuditMessages>()
+            .Done(c => c.IsMessageHandlingComplete)
+            .Run();
+
+            Assert.IsTrue(context.IsMessageHandledByTheAuditEndpoint);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsMessageHandlingComplete { get; set; }
+            public bool IsMessageHandledByTheAuditEndpoint { get; set; }
+        }
+
+        public class EndpointWithAuditOff : EndpointConfigurationBuilder
+        {
+           
+            public EndpointWithAuditOff()
+            {
+                // Although the AuditTo seems strange here, this test tries to fake the scenario where
+                // even though the user has specified audit config, because auditing is explicitly turned
+                // off, no messages should be audited.
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<Features.Audit>())
+                    .AuditTo<EndpointThatHandlesAuditMessages>();
+
+            }
+
+            class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+                }
+            }
+        }
+
+        public class EndpointWithAuditOn : EndpointConfigurationBuilder
+        {
+
+            public EndpointWithAuditOn()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<EndpointThatHandlesAuditMessages>();
+            }
+
+            class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+                }
+            }
+        }
+
+        public class EndpointThatHandlesAuditMessages : EndpointConfigurationBuilder
+        {
+
+            public EndpointThatHandlesAuditMessages()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandledByTheAuditEndpoint = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeAudited : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_Deferring_a_message.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_Deferring_a_message.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_Deferring_a_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_be_received()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.Defer(TimeSpan.FromSeconds(3), new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.IsTrue(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_aborting_the_behavior_chain.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_aborting_the_behavior_chain.cs
@@ -1,0 +1,73 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_aborting_the_behavior_chain : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Subsequent_handlers_will_not_be_invoked()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.Send(Address.Local, new SomeMessage())))
+                .Done(c => c.FirstHandlerInvoked)
+                .Run();
+
+            Assert.That(context.FirstHandlerInvoked, Is.True);
+            Assert.That(context.SecondHandlerInvoked, Is.False);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool FirstHandlerInvoked { get; set; }
+            public bool SecondHandlerInvoked { get; set; }
+        }
+
+        [Serializable]
+        public class SomeMessage : IMessage { }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class EnsureOrdering : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.Specify(First<FirstHandler>.Then<SecondHandler>());
+                }
+            }
+
+            class FirstHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                
+                public IBus Bus { get; set; }
+                
+                public void Handle(SomeMessage message)
+                {
+                    Context.FirstHandlerInvoked = true;
+
+                    Bus.DoNotContinueDispatchingCurrentMessageToHandlers();
+                }
+            }
+
+            class SecondHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                
+                public void Handle(SomeMessage message)
+                {
+                    Context.SecondHandlerInvoked = true;
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_handling_current_message_later.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_handling_current_message_later.cs
@@ -1,0 +1,157 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using System.Linq;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_handling_current_message_later : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_commit_unit_of_work()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.Send(Address.Local, new SomeMessage())))
+                .Done(c => c.Done)
+                .Run();
+
+            Assert.That(context.AnotherMessageReceivedCount, Is.EqualTo(2), 
+                "First handler sends a message to self, which should result in AnotherMessage being dispatched twice");
+        }
+
+        [Test, Description("NOTE the double negation - we should probably modify this behavior somehow")]
+        public void Should_not_not_execute_subsequent_handlers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.Send(Address.Local, new SomeMessage())))
+                .Done(c => c.Done)
+                .Run();
+
+            Assert.That(context.ThirdHandlerInvocationCount, Is.EqualTo(2), 
+                "Since calling HandleCurrentMessageLater does not discontinue message dispatch, the third handler should be called twice as well");
+        }
+
+        [Test]
+        public void Handlers_are_executed_in_the_right_order()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.Send(Address.Local, new SomeMessage())))
+                .Done(c => c.Done)
+                .Run();
+
+            var events = context.Events;
+            CollectionAssert
+                .AreEquivalent(new[]
+                               {
+                                   "FirstHandler:Executed",
+                                   "SecondHandler:Sending message to the back of the queue",
+                                   "ThirdHandler:Executed",
+                                   "FirstHandler:Executed",
+                                   "SecondHandler:Handling the message this time",
+                                   "ThirdHandler:Executed"
+                               },
+                    events);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string[] Events { get; set; }
+            
+            public bool SomeMessageHasBeenRequeued { get; set; }
+
+            public bool Done
+            {
+                get { return ThirdHandlerInvocationCount >= 2 && AnotherMessageReceivedCount == 2; }
+            }
+
+            public int AnotherMessageReceivedCount { get; set; }
+            
+            public int ThirdHandlerInvocationCount { get; set; }
+        }
+
+        [Serializable]
+        public class SomeMessage : IMessage { }
+
+        [Serializable]
+        public class AnotherMessage : IMessage { }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class EnsureOrdering : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.Specify(First<FirstHandler>.Then<SecondHandler>().AndThen<ThirdHandler>());
+                }
+            }
+
+            class FirstHandler : IHandleMessages<SomeMessage>, IHandleMessages<AnotherMessage>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+
+                public void Handle(SomeMessage message)
+                {
+                    Context.RegisterEvent("FirstHandler:Executed");
+                    Bus.SendLocal(new AnotherMessage());
+                }
+
+                public void Handle(AnotherMessage message)
+                {
+                    Context.AnotherMessageReceivedCount++;
+                }
+            }
+
+            class SecondHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+                public void Handle(SomeMessage message)
+                {
+                    if (!Context.SomeMessageHasBeenRequeued)
+                    {
+                        Context.RegisterEvent("SecondHandler:Sending message to the back of the queue");
+                        Bus.HandleCurrentMessageLater();
+                        Context.SomeMessageHasBeenRequeued = true;
+                    }
+                    else
+                    {
+                        Context.RegisterEvent("SecondHandler:Handling the message this time");
+                    }
+                }
+            }
+
+            class ThirdHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                public void Handle(SomeMessage message)
+                {
+                    Context.RegisterEvent("ThirdHandler:Executed");
+                    Context.ThirdHandlerInvocationCount++;
+                }
+            }
+        }
+    }
+
+    static class ContextEx
+    {
+        public static void RegisterEvent(this When_handling_current_message_later.Context context, string description)
+        {
+            context.Events = context.Events
+                .Concat(new[] {description})
+                .ToArray();
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_registering_a_callback_for_a_local_message.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_registering_a_callback_for_a_local_message.cs
@@ -1,0 +1,64 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_registering_a_callback_for_a_local_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_trigger_the_callback_when_the_response_comes_back()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointWithLocalCallback>(b=>b.Given(
+                        (bus,context)=>bus.SendLocal(new MyRequest()).Register(r =>
+                        {
+                            Assert.True(context.HandlerGotTheRequest);
+                            context.CallbackFired = true;
+                        })))
+                    .Done(c => c.CallbackFired)
+                    .Repeat(r =>r.For(Transports.Default))
+                    .Should(c =>
+                    {
+                        Assert.True(c.CallbackFired);
+                        Assert.True(c.HandlerGotTheRequest);
+                    })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerGotTheRequest { get; set; }
+
+            public bool CallbackFired { get; set; }
+        }
+
+        public class EndpointWithLocalCallback : EndpointConfigurationBuilder
+        {
+            public EndpointWithLocalCallback()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Assert.False(Context.CallbackFired);
+                    Context.HandlerGotTheRequest = true;
+
+                    Bus.Return(1);
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage{}
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_that_is_registered_multiple_times_to_another_endpoint.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_that_is_registered_multiple_times_to_another_endpoint.cs
@@ -1,0 +1,100 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using System.Threading;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_sending_a_message_that_is_registered_multiple_times_to_another_endpoint : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void First_registration_should_be_the_final_destination()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MyCommand1())))
+                    .WithEndpoint<Receiver1>()
+                    .WithEndpoint<Receiver2>()
+                    .Done(c => c.WasCalled1 || c.WasCalled2)
+                    .Run();
+
+            Assert.IsTrue(context.WasCalled1);
+            Assert.IsFalse(context.WasCalled2);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled1 { get; set; }
+            public bool WasCalled2 { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MyCommand1>(typeof(Receiver1))
+                    .AddMapping<MyCommand2>(typeof(Receiver2));
+            }
+        }
+
+        public class Receiver1 : EndpointConfigurationBuilder
+        {
+            public Receiver1()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyBaseCommand>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyBaseCommand message)
+                {
+                    Context.WasCalled1 = true;
+                    Thread.Sleep(2000); // Just to be sure the other receiver is finished
+                }
+            }
+        }
+
+        public class Receiver2 : EndpointConfigurationBuilder
+        {
+            public Receiver2()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyBaseCommand>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyBaseCommand message)
+                {
+                    Context.WasCalled2 = true;
+                    Thread.Sleep(2000); // Just to be sure the other receiver is finished
+                }
+            }
+        }
+
+        [Serializable]
+        public abstract class MyBaseCommand : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MyCommand1 : MyBaseCommand
+        {
+        }
+
+        [Serializable]
+        public class MyCommand2 : MyBaseCommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_to_another_endpoint.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_to_another_endpoint.cs
@@ -1,0 +1,99 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using System.Collections.Generic;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_sending_a_message_to_another_endpoint : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_the_message()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<Sender>(b => b.Given((bus, context) =>
+                    {
+                        bus.OutgoingHeaders["MyStaticHeader"] = "StaticHeaderValue";
+                        bus.Send<MyMessage>(m=>
+                        {
+                            m.Id = context.Id;
+                            m.SetHeader("MyHeader","MyHeaderValue");
+                        });
+                    }))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.WasCalled)
+                    .Repeat(r =>r.For(Serializers.Binary)
+                                  .For<AllBuilders>()
+                    )
+                    .Should(c =>
+                        {
+                            Assert.True(c.WasCalled, "The message handler should be called");
+                            Assert.AreEqual(1, c.TimesCalled, "The message handler should only be invoked once");
+                            Assert.True(c.ReceivedHeaders[Headers.OriginatingEndpoint].Contains("Sender"), "The sender should attach its endpoint name as a header");
+                            Assert.True(c.ReceivedHeaders[Headers.ProcessingEndpoint].Contains("Receiver"), "The receiver should attach its endpoint name as a header");
+                            Assert.AreEqual("StaticHeaderValue",c.ReceivedHeaders["MyStaticHeader"], "Static headers should be attached to outgoing messages");
+                            Assert.AreEqual("MyHeaderValue", c.MyHeader, "Static headers should be attached to outgoing messages");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+
+            public int TimesCalled { get; set; }
+
+            public IDictionary<string, string> ReceivedHeaders { get; set; }
+
+            public Guid Id { get; set; }
+
+            public string MyHeader { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MyMessage>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+
+            public IBus Bus { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                if (Context.Id != message.Id)
+                    return;
+
+                Context.TimesCalled++;
+
+                Context.MyHeader = message.GetHeader("MyHeader");
+
+                Context.ReceivedHeaders = Bus.CurrentMessageContext.Headers;
+
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_with_no_correlation_id.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_with_no_correlation_id.cs
@@ -1,0 +1,73 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_sending_a_message_with_no_correlation_id : NServiceBusAcceptanceTest
+    {  
+        [Test]
+        public void Should_use_the_message_id_as_the_correlation_id()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<CorrelationEndpoint>(b => b.Given(bus => bus.Send(Address.Local, new MyRequest())))
+                    .Done(c => c.GotRequest)
+                    .Run();
+
+            Assert.AreEqual(context.MessageIdReceived, context.CorrelationIdReceived, "Correlation id should match MessageId");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string MessageIdReceived { get; set; }
+            public bool GotRequest { get; set; }
+            public string CorrelationIdReceived { get; set; }
+        }
+
+        public class CorrelationEndpoint : EndpointConfigurationBuilder
+        {
+            public CorrelationEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class GetValueOfIncomingCorrelationId:IMutateIncomingTransportMessages,INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    Context.CorrelationIdReceived = transportMessage.CorrelationId;
+                    Context.MessageIdReceived = transportMessage.Id;
+                }
+
+                public void Init()
+                {
+                    Configure.Component<GetValueOfIncomingCorrelationId>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest response)
+                {
+                    Context.GotRequest = true;
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_starting_a_send_only.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_starting_a_send_only.cs
@@ -1,0 +1,22 @@
+﻿﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+ {
+     using System;
+     using NUnit.Framework;
+
+     public class When_starting_a_send_only : NServiceBusAcceptanceTest
+     {
+         [Test]
+         public void Should_not_need_audit_or_fault_forwarding_config_to_start()
+         {
+             using ((IDisposable)Configure.With(new Type[]
+                                  {
+                                  })
+                 .DefaultBuilder()
+                 .UnicastBus()
+                 .SendOnly())
+             {
+             }
+
+         }
+     }
+ }

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_custom_correlation_id.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_custom_correlation_id.cs
@@ -1,0 +1,74 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_using_a_custom_correlation_id : NServiceBusAcceptanceTest
+    {
+        static string CorrelationId = "my_custom_correlation_id";
+       
+        [Test]
+        public void Should_use_the_given_id_as_the_transport_level_correlation_id()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<CorrelationEndpoint>(b => b.Given(bus => bus.Send(Address.Local, CorrelationId, new MyRequest())))
+                    .Done(c => c.GotRequest)
+                    .Run();
+
+            Assert.AreEqual(CorrelationId, context.CorrelationIdReceived, "Correlation ids should match");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotRequest { get; set; }
+
+            public string CorrelationIdReceived { get; set; }
+        }
+
+        public class CorrelationEndpoint : EndpointConfigurationBuilder
+        {
+            public CorrelationEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class GetValueOfIncomingCorrelationId:IMutateIncomingTransportMessages,INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    Context.CorrelationIdReceived = transportMessage.CorrelationId;
+                }
+
+                public void Init()
+                {
+                    Configure.Component<GetValueOfIncomingCorrelationId>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest response)
+                {
+                    Context.GotRequest = true;
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_greedy_convention.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_greedy_convention.cs
@@ -1,0 +1,64 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_a_greedy_convention : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_the_message()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<EndPoint>(b => b.Given((bus, context) => bus.SendLocal(new MyMessage
+                    {Id = context.Id})))
+                    .Done(c => c.WasCalled)
+                    .Repeat(r =>r
+                        .For(Transports.Msmq)
+                    )
+                    .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+
+            public Guid Id { get; set; }
+        }
+
+        public class EndPoint : EndpointConfigurationBuilder
+        {
+            public EndPoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.DefiningMessagesAs(MessageConvention));
+            }
+
+            static bool MessageConvention(Type t)
+            {
+                return t.Namespace != null && 
+                    (t.Namespace.EndsWith(".Messages") ||  (t == typeof(MyMessage)));
+            }
+        }
+
+        [Serializable]
+        public class MyMessage
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+            public void Handle(MyMessage message)
+            {
+                if (Context.Id != message.Id)
+                    return;
+
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_message_with_TimeToBeReceived_has_expired.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_message_with_TimeToBeReceived_has_expired.cs
@@ -1,0 +1,49 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_using_a_message_with_TimeToBeReceived_has_expired : NServiceBusAcceptanceTest
+    {
+        [Test, Ignore("The TTL will only be started at the moment the timeoutmanager sends the message back, still giving the test a second to receive it")]
+        public void Message_should_not_be_received()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.Defer(TimeSpan.FromSeconds(5), new MyMessage())))
+                    .Run(TimeSpan.FromSeconds(10));
+            Assert.IsFalse(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        [TimeToBeReceived("00:00:01")]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_message_with_TimeToBeReceived_has_not_expired.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_message_with_TimeToBeReceived_has_not_expired.cs
@@ -1,0 +1,53 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_using_a_message_with_TimeToBeReceived_has_not_expired : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_be_received()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.IsTrue(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        [TimeToBeReceived("00:00:10")]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_callbacks_in_a_scaleout_scenario.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_callbacks_in_a_scaleout_scenario.cs
@@ -1,0 +1,125 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+    using Support;
+
+    public class When_using_callbacks_in_a_scaleout_scenario : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Each_client_should_have_a_unique_input_queue_to_avoid_processing_each_others_callbacks()
+        {
+            Scenario.Define(() => new Context{Id = Guid.NewGuid()})
+                    .WithEndpoint<Client>(b => b.CustomConfig(c=>RuntimeEnvironment.MachineNameAction = () => "ClientA")
+                        .Given((bus, context) => bus.Send(new MyRequest { Id = context.Id, Client = RuntimeEnvironment.MachineName })
+                                                        .Register(r => context.CallbackAFired = true)))
+                    .WithEndpoint<Client>(b => b.CustomConfig(c=>RuntimeEnvironment.MachineNameAction = () => "ClientB")
+                        .Given((bus, context) => bus.Send(new MyRequest { Id = context.Id, Client = RuntimeEnvironment.MachineName })
+                         .Register(r => context.CallbackBFired = true)))
+                    .WithEndpoint<Server>()
+                    .Done(c => c.ClientAGotResponse && c.ClientBGotResponse)
+                    .Repeat(r =>r.For<AllBrokerTransports>()
+                    )
+                    .Should(c =>
+                        {
+                            Assert.True(c.CallbackAFired, "Callback on ClientA should fire");
+                            Assert.True(c.CallbackBFired, "Callback on ClientB should fire");
+                            Assert.False(c.ResponseEndedUpAtTheWrongClient, "One of the responses ended up at the wrong client");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public bool ClientAGotResponse { get; set; }
+
+            public bool ClientBGotResponse { get; set; }
+
+            public bool ResponseEndedUpAtTheWrongClient { get; set; }
+
+            public bool CallbackAFired { get; set; }
+
+            public bool CallbackBFired { get; set; }
+        }
+
+        public class Client : EndpointConfigurationBuilder
+        {
+            public Client()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.ScaleOut(s => s.UseUniqueBrokerQueuePerMachine()))
+                    .AddMapping<MyRequest>(typeof(Server));
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyResponse response)
+                {
+                    if (Context.Id != response.Id)
+                        return;
+
+                    if (RuntimeEnvironment.MachineName == "ClientA")
+                        Context.ClientAGotResponse = true;
+                    else
+                    {
+                        Context.ClientBGotResponse = true;
+                    }
+
+                    if (RuntimeEnvironment.MachineName != response.Client)
+                        Context.ResponseEndedUpAtTheWrongClient = true;
+                }
+            }
+        }
+
+        public class Server : EndpointConfigurationBuilder
+        {
+            public Server()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    if (Context.Id != request.Id)
+                        return;
+
+
+                    Bus.Reply(new MyResponse { Id = request.Id,Client = request.Client });
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+            public Guid Id { get; set; }
+
+            public string Client { get; set; }
+        }
+
+        [Serializable]
+        public class MyResponse : IMessage
+        {
+            public Guid Id { get; set; }
+
+            public string Client { get; set; }
+        }
+
+
+    
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BusStartStop/When_bus_start_and_stops_with_a_pending_message.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BusStartStop/When_bus_start_and_stops_with_a_pending_message.cs
@@ -1,0 +1,58 @@
+﻿namespace NServiceBus.AcceptanceTests.BusStartStop
+{
+    using System;
+    using System.Threading;
+    using AcceptanceTesting.Support;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_bus_start_and_stops_with_a_pending_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_throw()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => SendMessages(b))
+                    .Run(TimeSpan.FromMilliseconds(100));
+
+            Thread.Sleep(100);
+        }
+
+
+        EndpointBehaviorBuilder<Context> SendMessages(EndpointBehaviorBuilder<Context> b)
+        {
+            return b.Given((bus, context) => bus.SendLocal(new Message()));
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class MessageHandler : IHandleMessages<Message>
+            {
+                public void Handle(Message message)
+                {
+                    Thread.Sleep(100);
+                }
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BusStartStop/When_bus_start_raises_an_inmemory_message.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BusStartStop/When_bus_start_raises_an_inmemory_message.cs
@@ -1,0 +1,69 @@
+﻿namespace NServiceBus.AcceptanceTests.BusStartStop
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+#pragma warning disable 612, 618
+    public class When_bus_start_raises_an_inmemory_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_throw()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.GotMessage)
+                .Repeat(r => r.For<AllBuilders>())
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotMessage;
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class MessageHandler : IHandleMessages<Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(Message message)
+                {
+                    Context.GotMessage = true;
+                }
+            }
+        }
+
+        public class Foo : IWantToRunWhenBusStartsAndStops
+        {
+            public IBus Bus { get; set; }
+
+            public void Start()
+            {
+                Bus.InMemory.Raise(new Message());
+            }
+
+            public void Stop()
+            {
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+
+    }
+#pragma warning restore  612, 618
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Configuration/When_a_config_override_is_found.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Configuration/When_a_config_override_is_found.cs
@@ -1,0 +1,65 @@
+﻿namespace NServiceBus.AcceptanceTests.Configuration
+{
+    using Config;
+    using Config.ConfigurationSource;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Faults.Forwarder;
+    using NUnit.Framework;
+    using Unicast;
+    using Unicast.Transport;
+
+    public class When_a_config_override_is_found : NServiceBusAcceptanceTest
+    {
+        static Address CustomErrorQ = Address.Parse("MyErrorQ");
+
+        [Test]
+        public void Should_be_used_instead_of_pulling_the_settings_from_appconfig()
+        {
+            var context = Scenario.Define<Context>()
+                    .WithEndpoint<ConfigOverrideEndpoint>(b => b.When(c => c.EndpointsStarted, (bus, cc) =>
+                        {
+                            var unicastBus = (UnicastBus)bus;
+                            var transport = (TransportReceiver)unicastBus.Transport;
+                            var fm = (FaultManager)transport.FailureManager;
+
+                            cc.ErrorQueueUsedByTheEndpoint = fm.ErrorQueue;
+                            cc.IsDone = true;
+                        }))
+                    .Done(c => c.IsDone)
+                    .Run();
+
+            Assert.AreEqual(CustomErrorQ, context.ErrorQueueUsedByTheEndpoint, "The error queue should have been changed");
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsDone { get; set; }
+
+            public Address ErrorQueueUsedByTheEndpoint { get; set; }
+        }
+
+        public class ConfigOverrideEndpoint : EndpointConfigurationBuilder
+        {
+            public ConfigOverrideEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.MessageForwardingInCaseOfFault());
+            }
+
+            public class ConfigErrorQueue : IProvideConfiguration<MessageForwardingInCaseOfFaultConfig>
+            {
+                public MessageForwardingInCaseOfFaultConfig GetConfiguration()
+                {
+
+                    return new MessageForwardingInCaseOfFaultConfig
+                    {
+                        ErrorQueue = CustomErrorQ.ToString()
+                    };
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
@@ -1,0 +1,67 @@
+﻿namespace NServiceBus.AcceptanceTests.DataBus
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_sending_databus_properties:NServiceBusAcceptanceTest
+    {
+        static byte[] PayloadToSend = new byte[1024 * 1024 * 10];
+
+        [Test]
+        public void Should_receive_the_message_the_largeproperty_correctly()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus=> bus.Send(new MyMessageWithLargePayload
+                        {
+                            Payload = new DataBusProperty<byte[]>(PayloadToSend) 
+                        })))
+                    .WithEndpoint<Receiver>()
+                    .Done(context => context.ReceivedPayload != null)
+                    .Repeat(r => r.For<AllSerializers>())
+                    .Should(c => Assert.AreEqual(PayloadToSend, c.ReceivedPayload, "The large payload should be marshalled correctly using the databus"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public byte[] ReceivedPayload { get; set; }
+        }
+
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c => c.FileShareDataBus(@".\databus\sender"))
+                    .AddMapping<MyMessageWithLargePayload>(typeof (Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c => c.FileShareDataBus(@".\databus\sender"));
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessageWithLargePayload>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessageWithLargePayload messageWithLargePayload)
+                {
+                    Context.ReceivedPayload = messageWithLargePayload.Payload.Value;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessageWithLargePayload : ICommand
+        {
+            public DataBusProperty<byte[]> Payload { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System;
+    using System.Collections.Generic;
+    using Config;
+    using Config.ConfigurationSource;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_encryption : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_decrypted_message()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageWithSecretData
+                        {
+                            Secret = "betcha can't guess my secret",
+                            SubProperty = new MySecretSubProperty {Secret = "My sub secret"},
+                            CreditCards = new List<CreditCardDetails>
+                                {
+                                    new CreditCardDetails
+                                        {
+                                            ValidTo = DateTime.UtcNow.AddYears(1),
+                                            Number = "312312312312312"
+                                        },
+                                    new CreditCardDetails
+                                        {
+                                            ValidTo = DateTime.UtcNow.AddYears(2),
+                                            Number = "543645546546456"
+                                        }
+                                }
+                        })))
+                    .Done(c => c.Done)
+                    .Repeat(r => r.For<AllSerializers>())
+                    .Should(c =>
+                        {
+                            Assert.AreEqual("betcha can't guess my secret", c.Secret);
+                            Assert.AreEqual("My sub secret", c.SubPropertySecret);
+                            CollectionAssert.AreEquivalent(new List<string> { "312312312312312", "543645546546456" }, c.CreditCards);
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+
+            public string Secret { get; set; }
+
+            public string SubPropertySecret { get; set; }
+
+            public List<string> CreditCards { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.RijndaelEncryptionService());
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+
+                    Context.SubPropertySecret = message.SubProperty.Secret.Value;
+
+                    Context.CreditCards = new List<string>
+                    {
+                        message.CreditCards[0].Number.Value, 
+                        message.CreditCards[1].Number.Value
+                    };
+
+                    Context.Done = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageWithSecretData : IMessage
+        {
+            public WireEncryptedString Secret { get; set; }
+            public MySecretSubProperty SubProperty { get; set; }
+            public List<CreditCardDetails> CreditCards { get; set; }
+        }
+
+        [Serializable]
+        public class CreditCardDetails
+        {
+            public DateTime ValidTo { get; set; }
+            public WireEncryptedString Number { get; set; }
+        }
+
+        [Serializable]
+        public class MySecretSubProperty
+        {
+            public WireEncryptedString Secret { get; set; }
+        }
+
+        public class ConfigureEncryption: IProvideConfiguration<RijndaelEncryptionServiceConfig>
+        {
+            RijndaelEncryptionServiceConfig rijndaelEncryptionServiceConfig = new RijndaelEncryptionServiceConfig { Key = "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6" };
+
+            public RijndaelEncryptionServiceConfig GetConfiguration()
+            {
+                return rijndaelEncryptionServiceConfig;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption_with_custom_service.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption_with_custom_service.cs
@@ -1,0 +1,75 @@
+﻿namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System.Linq;
+    using NServiceBus.Encryption;
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_encryption_with_custom_service : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_decrypted_message()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageWithSecretData
+                        {
+                            Secret = "betcha can't guess my secret"
+                        })))
+                    .Done(c => c.Done)
+                    .Repeat(r => r.For<AllSerializers>())
+                    .Should(c => Assert.AreEqual("betcha can't guess my secret", c.Secret))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+            public string Secret { get; set; }
+        }
+        
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Configurer.RegisterSingleton<IEncryptionService>(new MyEncryptionService()));
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+                    Context.Done = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageWithSecretData : IMessage
+        {
+            public WireEncryptedString Secret { get; set; }
+        }
+
+
+        public class MyEncryptionService : IEncryptionService
+        {
+            public EncryptedValue Encrypt(string value)
+            {
+                return new EncryptedValue
+                {
+                    EncryptedBase64Value = new string(value.Reverse().ToArray())
+                };
+            }
+
+            public string Decrypt(EncryptedValue encryptedValue)
+            {
+                return new string(encryptedValue.EncryptedBase64Value.Reverse().ToArray());
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption_with_multikey.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption_with_multikey.cs
@@ -1,0 +1,110 @@
+﻿namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System;
+    using Config;
+    using Config.ConfigurationSource;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_encryption_with_multikey : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_decrypted_message()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given((bus, context) => bus.Send(new MessageWithSecretData
+                        {
+                            Secret = "betcha can't guess my secret",
+                        })))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.Done)
+                    .Repeat(r => r.For<AllSerializers>())
+                    .Should(c => Assert.AreEqual("betcha can't guess my secret", c.Secret))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+
+            public string Secret { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c => c.RijndaelEncryptionService())
+                    .AddMapping<MessageWithSecretData>(typeof(Receiver));
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+                    Context.Done = true;
+                }
+            }
+
+            public class ConfigureEncryption : IProvideConfiguration<RijndaelEncryptionServiceConfig>
+            {
+                public RijndaelEncryptionServiceConfig GetConfiguration()
+                {
+                    return new RijndaelEncryptionServiceConfig
+                    {
+                        Key = "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"
+                    };
+                }
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c => c.RijndaelEncryptionService());
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+                    Context.Done = true;
+                }
+            }
+
+            public class ConfigureEncryption : IProvideConfiguration<RijndaelEncryptionServiceConfig>
+            {
+                public RijndaelEncryptionServiceConfig GetConfiguration()
+                {
+                    return new RijndaelEncryptionServiceConfig
+                    {
+                        Key = "adDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6",
+                        ExpiredKeys = new RijndaelExpiredKeyCollection
+                        {
+                            new RijndaelExpiredKey
+                            {
+                                Key = "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"
+                            }
+                        }
+                    };
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageWithSecretData : IMessage
+        {
+            public WireEncryptedString Secret { get; set; }
+        }
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -1,0 +1,187 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Collections.Generic;
+    using ObjectBuilder.Common;
+    using ObjectBuilder.Common.Config;
+    using Persistence.InMemory.SagaPersister;
+    using Persistence.InMemory.SubscriptionStorage;
+    using Persistence.InMemory.TimeoutPersister;
+    using Persistence.Msmq.SubscriptionStorage;
+    using Persistence.Raven.SagaPersister;
+    using Persistence.Raven.SubscriptionStorage;
+    using Persistence.Raven.TimeoutPersister;
+    using ScenarioDescriptors;
+    using Serializers.Binary;
+    using Serializers.Json;
+    using Serializers.XML;
+
+    public static class ConfigureExtensions
+    {
+        public static string GetOrNull(this IDictionary<string, string> dictionary, string key)
+        {
+            if (!dictionary.ContainsKey(key))
+            {
+                return null;
+            }
+
+            return dictionary[key];
+        }
+
+        public static Configure DefineTransport(this Configure config, IDictionary<string, string> settings)
+        {
+            if (!settings.ContainsKey("Transport"))
+            {
+                settings = Transports.Default.Settings;
+            }
+
+            var transportType = Type.GetType(settings["Transport"]);
+
+            return config.UseTransport(transportType, () => settings["Transport.ConnectionString"]);
+        }
+
+        public static Configure DefineSerializer(this Configure config, string serializer)
+        {
+            if (string.IsNullOrEmpty(serializer))
+            {
+                return config; //xml is the default
+            }
+
+            var type = Type.GetType(serializer);
+
+            if (type == typeof(XmlMessageSerializer))
+            {
+                Configure.Serialization.Xml();
+                return config;
+            }
+
+            if (type == typeof(JsonMessageSerializer))
+            {
+                Configure.Serialization.Json();
+                return config;
+            }
+
+            if (type == typeof(BsonMessageSerializer))
+            {
+                Configure.Serialization.Bson();
+                return config;
+            }
+
+            if (type == typeof(BinaryMessageSerializer))
+            {
+                Configure.Serialization.Binary();
+                return config;
+            }
+
+            throw new InvalidOperationException("Unknown serializer:" + serializer);
+        }
+
+        public static Configure DefineTimeoutPersister(this Configure config, string persister)
+        {
+            if (string.IsNullOrEmpty(persister))
+            {
+                persister = TimeoutPersisters.Default.Settings["TimeoutPersister"];
+            }
+
+            if (persister.Contains(typeof(InMemoryTimeoutPersistence).FullName))
+            {
+                return config.UseInMemoryTimeoutPersister();
+            }
+
+            if (persister.Contains(typeof(RavenTimeoutPersistence).FullName))
+            {
+                config.RavenPersistence(() => "url=http://localhost:8080");
+                return config.UseRavenTimeoutPersister();
+            }
+
+            CallConfigureForPersister(config, persister);
+
+            return config;
+        }
+
+        public static Configure DefineSagaPersister(this Configure config, string persister)
+        {
+            if (string.IsNullOrEmpty(persister))
+            {
+                persister = SagaPersisters.Default.Settings["SagaPersister"];
+            }
+
+            if (persister.Contains(typeof(InMemorySagaPersister).FullName))
+            {
+                return config.InMemorySagaPersister();
+            }
+
+            if (persister.Contains(typeof(RavenSagaPersister).FullName))
+            {
+                config.RavenPersistence(() => "url=http://localhost:8080");
+                return config.RavenSagaPersister();
+            }
+
+            CallConfigureForPersister(config, persister);
+
+            return config;
+        }
+
+        public static Configure DefineSubscriptionStorage(this Configure config, string persister)
+        {
+            if (string.IsNullOrEmpty(persister))
+            {
+                persister = SubscriptionPersisters.Default.Settings["SubscriptionStorage"];
+            }
+
+            if (persister.Contains(typeof(InMemorySubscriptionStorage).FullName))
+            {
+                return config.InMemorySubscriptionStorage();
+            }
+
+            if (persister.Contains(typeof(RavenSubscriptionStorage).FullName))
+            {
+                config.RavenPersistence(() => "url=http://localhost:8080");
+                return config.RavenSubscriptionStorage();
+            }
+
+            if (persister.Contains(typeof(MsmqSubscriptionStorage).FullName))
+            {
+                return config.MsmqSubscriptionStorage();
+            }
+
+            CallConfigureForPersister(config, persister);
+
+            return config;
+        }
+
+        static void CallConfigureForPersister(Configure config, string persister)
+        {
+            var type = Type.GetType(persister);
+
+            var typeName = "Configure" + type.Name;
+
+            var configurerType = Type.GetType(typeName, false);
+
+            if (configurerType == null)
+            {
+                return;
+            }
+
+            var configurer = Activator.CreateInstance(configurerType);
+
+            dynamic dc = configurer;
+
+            dc.Configure(config);
+        }
+
+        public static Configure DefineBuilder(this Configure config, string builder)
+        {
+            if (string.IsNullOrEmpty(builder))
+            {
+                return config.DefaultBuilder();
+            }
+
+            var container = (IContainer) Activator.CreateInstance(Type.GetType(builder));
+
+            ConfigureCommon.With(config, container);
+
+            return config;
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ContextAppender.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ContextAppender.cs
@@ -1,0 +1,35 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using AcceptanceTesting;
+    using AcceptanceTesting.Support;
+    using log4net.Appender;
+    using log4net.Core;
+
+    public class ContextAppender : AppenderSkeleton
+    {
+        public ContextAppender(ScenarioContext context, EndpointConfiguration endpointConfiguration)
+        {
+            this.context = context;
+            this.endpointConfiguration = endpointConfiguration;
+        }
+
+        protected override void Append(LoggingEvent loggingEvent)
+        {
+            if (!endpointConfiguration.AllowExceptions && loggingEvent.ExceptionObject != null)
+            {
+                lock (context)
+                {
+                    context.Exceptions += loggingEvent.ExceptionObject + "/n/r";
+                }
+            }
+            if (loggingEvent.Level >= Level.Warn)
+            {
+                context.RecordLog(endpointConfiguration.EndpointName, loggingEvent.Level.ToString(), loggingEvent.RenderedMessage);
+            }
+
+        }
+
+        ScenarioContext context;
+        readonly EndpointConfiguration endpointConfiguration;
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -1,0 +1,84 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using AcceptanceTesting.Support;
+    using Config.ConfigurationSource;
+    using Hosting.Helpers;
+    using NServiceBus;
+    using Settings;
+
+    public class DefaultServer : IEndpointSetupTemplate
+    {
+        public Configure GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource)
+        {
+            var settings = runDescriptor.Settings;
+
+            SetLoggingLibrary.Log4Net(null, new ContextAppender(runDescriptor.ScenarioContext, endpointConfiguration));
+
+            var types = GetTypesToUse(endpointConfiguration);
+
+            var transportToUse = settings.GetOrNull("Transport");
+
+            Configure.Features.Enable<Features.Sagas>();
+
+            SettingsHolder.SetDefault("ScaleOut.UseSingleBrokerQueue", true);
+
+            var config = Configure.With(types)
+                            .DefineEndpointName(endpointConfiguration.EndpointName)
+                            .CustomConfigurationSource(configSource)
+                            .DefineBuilder(settings.GetOrNull("Builder"))
+                            .DefineSerializer(settings.GetOrNull("Serializer"))
+                            .DefineTransport(settings)
+                            .DefineSagaPersister(settings.GetOrNull("SagaPersister"));
+
+            if (transportToUse == null ||
+                transportToUse.Contains("Msmq") ||
+                transportToUse.Contains("SqlServer") ||
+                transportToUse.Contains("RabbitMq"))
+            {
+                config.DefineTimeoutPersister(settings.GetOrNull("TimeoutPersister"));
+            }
+
+            if (transportToUse == null || transportToUse.Contains("Msmq") || transportToUse.Contains("SqlServer"))
+            {
+                config.DefineSubscriptionStorage(settings.GetOrNull("SubscriptionStorage"));
+            }
+
+            return config.UnicastBus();
+        }
+
+        static IEnumerable<Type> GetTypesToUse(EndpointConfiguration endpointConfiguration)
+        {
+            var assemblies = new AssemblyScanner().GetScannableAssemblies();
+
+            var types = assemblies.Assemblies
+                //exclude all test types by default
+                                  .Where(a => a != Assembly.GetExecutingAssembly())
+                                  .SelectMany(a => a.GetTypes());
+
+
+            types = types.Union(GetNestedTypeRecursive(endpointConfiguration.BuilderType.DeclaringType, endpointConfiguration.BuilderType));
+
+            types = types.Union(endpointConfiguration.TypesToInclude);
+
+            return types.Where(t => !endpointConfiguration.TypesToExclude.Contains(t)).ToList();
+        }
+
+        static IEnumerable<Type> GetNestedTypeRecursive(Type rootType, Type builderType)
+        {
+            yield return rootType;
+
+            if (typeof(IEndpointConfigurationFactory).IsAssignableFrom(rootType) && rootType != builderType)
+                yield break;
+
+            foreach (var nestedType in rootType.GetNestedTypes(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic).SelectMany(t => GetNestedTypeRecursive(t, builderType)))
+            {
+                yield return nestedType;
+            }
+        }
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/SerializerCorrupter.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/SerializerCorrupter.cs
@@ -1,0 +1,17 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Reflection;
+
+    static class SerializerCorrupter
+    {
+
+        public static void Corrupt()
+        {
+            var msmqUtilitiesType = Type.GetType("NServiceBus.Transports.Msmq.MsmqUtilities, NServiceBus.Core");
+            var headerSerializerField = msmqUtilitiesType.GetField("headerSerializer", BindingFlags.Static | BindingFlags.NonPublic);
+            headerSerializerField.SetValue(null, null);
+        }
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage.cs
@@ -1,0 +1,56 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_cant_convert_to_TransportMessage : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_send_message_to_error_queue()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus => bus.Send(new Message())))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.GetAllLogs().Any(l => l.Level == "error"))
+                    .Repeat(r => r.For(ScenarioDescriptors.Transports.Msmq))
+                    .Should(c =>
+                    {
+                        var logs = c.GetAllLogs();
+                        Assert.True(logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
+                    })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<Message>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                SerializerCorrupter.Corrupt();
+                EndpointSetup<DefaultServer>()
+                    .AllowExceptions();
+            }
+
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_NoTransactions.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_NoTransactions.cs
@@ -1,0 +1,58 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using IMessage = NServiceBus.IMessage;
+
+    public class When_cant_convert_to_TransportMessage_NoTransactions : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_send_message_to_error_queue()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus => bus.Send(new Message())))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.GetAllLogs().Any(l => l.Level == "error"))
+                    .Repeat(r => r.For(ScenarioDescriptors.Transports.Msmq))
+                    .Should(c =>
+                    {
+                        var logs = c.GetAllLogs();
+                        Assert.True(logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
+                    })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                Configure.Transactions.Disable();
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<Message>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                SerializerCorrupter.Corrupt();
+                Configure.Transactions.Disable();
+                EndpointSetup<DefaultServer>()
+                    .AllowExceptions();
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_SuppressedDTC.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_SuppressedDTC.cs
@@ -1,0 +1,57 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_cant_convert_to_TransportMessage_SuppressedDTC : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_send_message_to_error_queue()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus => bus.Send(new Message())))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.GetAllLogs().Any(l => l.Level == "error"))
+                    .Repeat(r => r.For(ScenarioDescriptors.Transports.Msmq))
+                    .Should(c =>
+                    {
+                        var logs = c.GetAllLogs();
+                        Assert.True(logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
+                    })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                Configure.Transactions.Advanced(settings => settings.DisableDistributedTransactions());
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<Message>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                SerializerCorrupter.Corrupt();
+                Configure.Transactions.Advanced(settings => settings.DisableDistributedTransactions());
+                EndpointSetup<DefaultServer>()
+                    .AllowExceptions();
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_response_between_sites.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_response_between_sites.cs
@@ -1,0 +1,105 @@
+﻿namespace NServiceBus.AcceptanceTests.Gateway
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_doing_request_response_between_sites : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Callback_should_be_fired()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<SiteA>(
+                    b => b.Given((bus, c) =>
+                        bus.SendToSites(new[] { "SiteB" }, new MyRequest())
+                            .Register(result => c.GotCallback = true)))
+                .WithEndpoint<SiteB>()
+                .Done(c => c.GotCallback)
+                .Run(TimeSpan.FromSeconds(2000));
+
+            Assert.IsTrue(context.GotCallback);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotCallback { get; set; }
+        }
+
+        public class SiteA : EndpointConfigurationBuilder
+        {
+            public SiteA()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway()
+                    .UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Sites = new SiteCollection
+                        {
+                            new SiteConfig
+                            {
+                                Key = "SiteB",
+                                Address = "http://localhost:25799/SiteB/",
+                                ChannelType = "http"
+                            }
+                        };
+
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25799/SiteA/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+            }
+        }
+
+        public class SiteB : EndpointConfigurationBuilder
+        {
+            public SiteB()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway().UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25799/SiteB/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public IBus Bus { get; set; }
+                public void Handle(MyRequest request)
+                {
+                    Bus.Reply(new MyResponse());
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : ICommand
+        {
+        }
+        [Serializable]
+        public class MyResponse : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_response_with_databus_between_sites.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_response_with_databus_between_sites.cs
@@ -1,0 +1,143 @@
+﻿namespace NServiceBus.AcceptanceTests.Gateway
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_doing_request_response_with_databus_between_sites : NServiceBusAcceptanceTest
+    {
+        static readonly byte[] PayloadToSend = new byte[1024 * 1024 * 10];
+
+        [Test]
+        public void Should_be_able_to_reply_to_the_message_using_databus()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<SiteA>(
+                    b => b.Given((bus, context) =>
+                        bus.SendToSites(new[] { "SiteB" }, new MyRequest { Payload = new DataBusProperty<byte[]>(PayloadToSend) })
+                            .Register(result => context.GotCallback = true)))
+                .WithEndpoint<SiteB>()
+                .Done(c => c.GotResponseBack && c.GotCallback)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c =>
+                {
+                    Assert.AreEqual(PayloadToSend, c.SiteBReceivedPayload,
+                        "The large payload should be marshalled correctly using the databus");
+                    Assert.AreEqual(PayloadToSend, c.SiteAReceivedPayloadInResponse,
+                        "The large payload should be marshalled correctly using the databus");
+                    Assert.AreEqual(@"http,http://localhost:25899/SiteA/", c.OriginatingSiteForRequest);
+                    Assert.AreEqual(@"http,http://localhost:25899/SiteB/", c.OriginatingSiteForResponse);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotResponseBack { get; set; }
+            public bool GotCallback { get; set; }
+            public byte[] SiteBReceivedPayload { get; set; }
+            public byte[] SiteAReceivedPayloadInResponse { get; set; }
+            public string OriginatingSiteForRequest { get; set; }
+            public string OriginatingSiteForResponse { get; set; }
+        }
+
+        public class SiteA : EndpointConfigurationBuilder
+        {
+            public SiteA()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway()
+                    .UseInMemoryGatewayPersister()
+                    .FileShareDataBus(@".\databus\siteA"))
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Sites = new SiteCollection
+                        {
+                            new SiteConfig
+                            {
+                                Key = "SiteB",
+                                Address = "http://localhost:25899/SiteB/",
+                                ChannelType = "http"
+                            }
+                        };
+
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25899/SiteA/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+
+                public void Handle(MyResponse response)
+                {
+                    Context.GotResponseBack = true;
+                    Context.SiteAReceivedPayloadInResponse = response.OriginalPayload.Value;
+                    
+                    // Inspect the headers to find the originating site address 
+                    Context.OriginatingSiteForResponse = Bus.CurrentMessageContext.Headers[Headers.OriginatingSite];
+                }
+            }
+        }
+
+        public class SiteB : EndpointConfigurationBuilder
+        {
+            public SiteB()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway().UseInMemoryGatewayPersister()
+                    .FileShareDataBus(@".\databus\siteB"))
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25899/SiteB/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public IBus Bus { get; set; }
+                public Context Context { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Context.SiteBReceivedPayload = request.Payload.Value;
+                    Bus.Reply(new MyResponse {OriginalPayload = request.Payload});
+
+                    // Inspect the headers to find the originating site address
+                    Context.OriginatingSiteForRequest = Bus.CurrentMessageContext.Headers[Headers.OriginatingSite];
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : ICommand
+        {
+            public DataBusProperty<byte[]> Payload { get; set; }
+        }
+
+        [Serializable]
+        public class MyResponse : IMessage
+        {
+            public DataBusProperty<byte[]> OriginalPayload { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_return.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_return.cs
@@ -1,0 +1,101 @@
+﻿namespace NServiceBus.AcceptanceTests.Gateway
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_doing_request_return : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Callback_should_be_fired()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<SiteA>(
+                    b => b.Given((bus, c) =>
+                        bus.SendToSites(new[] { "SiteB" }, new MyRequest())
+                            .Register(result => c.GotCallback = true)))
+                .WithEndpoint<SiteB>()
+                .Done(c => c.GotCallback)
+                .Run(TimeSpan.FromSeconds(2000));
+
+            Assert.IsTrue(context.GotCallback);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotCallback { get; set; }
+        }
+
+        public class SiteA : EndpointConfigurationBuilder
+        {
+            public SiteA()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway()
+                    .UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Sites = new SiteCollection
+                        {
+                            new SiteConfig
+                            {
+                                Key = "SiteB",
+                                Address = "http://localhost:25699/SiteB/",
+                                ChannelType = "http"
+                            }
+                        };
+
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25699/SiteA/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+            }
+        }
+
+        public class SiteB : EndpointConfigurationBuilder
+        {
+            public SiteB()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway().UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25699/SiteB/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public IBus Bus { get; set; }
+                public void Handle(MyRequest request)
+                {
+                    Bus.Return(1);
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_sending_a_message_to_another_site.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_sending_a_message_to_another_site.cs
@@ -1,0 +1,112 @@
+﻿namespace NServiceBus.AcceptanceTests.Gateway
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_sending_a_message_to_another_site : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_able_to_reply_to_the_message()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Headquarters>(b => b.Given(bus => bus.SendToSites(new[] { "SiteA" }, new MyRequest())))
+                    .WithEndpoint<SiteA>()
+                    .Done(c => c.GotResponseBack)
+                    .Repeat(r => r.For(Transports.Default)
+                    )
+                    .Should(c => Assert.IsTrue(c.GotResponseBack))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotResponseBack { get; set; }
+        }
+
+        public class Headquarters : EndpointConfigurationBuilder
+        {
+            public Headquarters()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway().UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                        {
+                            c.Sites = new SiteCollection
+                                {
+                                    new SiteConfig
+                                        {
+                                            Key = "SiteA",
+                                            Address = "http://localhost:25899/SiteA/",
+                                            ChannelType = "http"
+                                        }
+                                };
+
+                            c.Channels = new ChannelCollection
+                                {
+                                    new ChannelConfig
+                                        {
+                                             Address = "http://localhost:25899/Headquarters/",
+                                            ChannelType = "http"
+                                        }
+                                };
+
+
+                        });
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyResponse response)
+                {
+                    Context.GotResponseBack = true;
+                }
+            }
+        }
+
+        public class SiteA : EndpointConfigurationBuilder
+        {
+            public SiteA()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway().UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                        .WithConfig<GatewayConfig>(c =>
+                        {
+                            c.Channels = new ChannelCollection
+                                {
+                                    new ChannelConfig
+                                        {
+                                             Address = "http://localhost:25899/SiteA/",
+                                            ChannelType = "http"
+                                        }
+                                };
+                        });
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Bus.Reply(new MyResponse());
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+        }
+
+        [Serializable]
+        public class MyResponse : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_sending_a_message_via_the_gateway.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_sending_a_message_via_the_gateway.cs
@@ -1,0 +1,123 @@
+﻿namespace NServiceBus.AcceptanceTests.Gateway
+{
+    using System;
+    using System.IO;
+    using System.Net;
+    using System.Web;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Gateway.Utils;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+    
+    public class When_sending_a_message_via_the_gateway : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_process_message()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<Headquarters>(b => b.When(bus =>
+                {
+                    var webRequest = (HttpWebRequest)WebRequest.Create("http://localhost:25898/Headquarters/");
+                    webRequest.Method = "POST";
+                    webRequest.ContentType = "text/xml; charset=utf-8";
+                    webRequest.UserAgent = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)";
+
+                    webRequest.Headers.Add("Content-Encoding", "utf-8");
+                    webRequest.Headers.Add("NServiceBus.CallType", "Submit");
+                    webRequest.Headers.Add("NServiceBus.AutoAck", "true");
+                    webRequest.Headers.Add("MySpecialHeader", "MySpecialValue");
+                    webRequest.Headers.Add("NServiceBus.Id", Guid.NewGuid().ToString("N"));
+
+                    const string message = "<?xml version=\"1.0\" ?><Messages xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://tempuri.net/NServiceBus.AcceptanceTests.Gateway\"><MyRequest></MyRequest></Messages>";
+                    
+                    using (var messagePayload = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(message)))
+                    {
+                        webRequest.Headers.Add(HttpRequestHeader.ContentMd5, HttpUtility.UrlEncode(Hasher.Hash(messagePayload)));
+                        webRequest.ContentLength = messagePayload.Length;
+
+                        using (var requestStream = webRequest.GetRequestStream())
+                        {
+                            messagePayload.CopyTo(requestStream);
+                        }
+                    }
+
+                    while (true)
+                    {
+                        try
+                        {
+                            using (var myWebResponse = (HttpWebResponse) webRequest.GetResponse())
+                            {
+                                if (myWebResponse.StatusCode == HttpStatusCode.OK)
+                                {
+                                    break;
+                                }
+                            }
+                        }
+                        catch (WebException)
+                        {
+                        }
+                    }
+                }))
+                .Done(c => c.GotMessage)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c =>
+                {
+                    Assert.IsTrue(c.GotMessage);
+                    Assert.AreEqual("MySpecialValue", c.MySpecialHeader);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotMessage { get; set; }
+
+            public string MySpecialHeader { get; set; }
+        }
+
+        public class Headquarters : EndpointConfigurationBuilder
+        {
+            public Headquarters()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.RunGateway().UseInMemoryGatewayPersister();
+                    Configure.Serialization.Xml();
+                })
+                    .IncludeType<MyRequest>()
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25898/Headquarters/",
+                                ChannelType = "http"
+                            }
+                        };
+                    });
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest response)
+                {
+                    Context.GotMessage = true;
+                    Context.MySpecialHeader = Bus.GetMessageHeader(response, "MySpecialHeader");
+                }
+            }
+        }
+    }
+
+    [Serializable]
+    public class MyRequest : IMessage
+    {
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/HostInformation/When_a_message_is_received.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/HostInformation/When_a_message_is_received.cs
@@ -1,0 +1,74 @@
+﻿namespace NServiceBus.AcceptanceTests.HostInformation
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Unicast;
+
+    public class When_a_message_is_received : NServiceBusAcceptanceTest
+    {
+        static Guid hostId = new Guid("39365055-daf2-439e-b84d-acbef8fd803d");
+        const string displayName = "FooBar";
+        const string displayInstanceIdentifier = "FooBar is great!";
+
+        [Test]
+        public void Host_information_should_be_available_in_headers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(e => e.Given(b => b.SendLocal(new MyMessage())))
+                .Done(c => c.HostId != Guid.Empty)
+                .Run();
+
+            Assert.AreEqual(hostId, context.HostId);
+            Assert.AreEqual(displayName, context.HostDisplayName);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid HostId { get; set; }
+            public string HostDisplayName { get; set; }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                Context.HostId = new Guid(message.GetHeader(Headers.HostId));
+                Context.HostDisplayName = message.GetHeader(Headers.HostDisplayName);
+            }
+        }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        class OverrideHostInformation : IWantToRunWhenConfigurationIsComplete
+        {
+            public UnicastBus UnicastBus { get; set; }
+
+            public void Run()
+            {
+#pragma warning disable 618
+                var hostInformation = new Hosting.HostInformation(hostId, displayName, displayInstanceIdentifier);
+#pragma warning restore 618
+
+                UnicastBus.HostInformation = hostInformation;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_calling_DoNotContinueDispatchingCurrentMessageToHandlers_from_inmemory.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_calling_DoNotContinueDispatchingCurrentMessageToHandlers_from_inmemory.cs
@@ -1,0 +1,112 @@
+﻿namespace NServiceBus.AcceptanceTests.InMemory
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+    public class When_calling_DoNotContinueDispatchingCurrentMessageToHandlers_from_inmemory : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Subsequent_inmemory_handlers_will_not_be_invoked()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.SendLocal(new SomeMessage())))
+                .Done(c => c.SecondHandlerInvoked)
+                .Run();
+
+            Assert.IsTrue(context.FirstHandlerInvoked);
+            Assert.IsTrue(context.SecondHandlerInvoked);
+            Assert.IsTrue(context.InMemoryEventReceivedByHandler1);
+            Assert.IsFalse(context.InMemoryEventReceivedByHandler2);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool FirstHandlerInvoked { get; set; }
+            public bool SecondHandlerInvoked { get; set; }
+
+            public bool InMemoryEventReceivedByHandler1 { get; set; }
+            public bool InMemoryEventReceivedByHandler2 { get; set; }
+            
+        }
+
+        [Serializable]
+        public class SomeMessage : IMessage { }
+
+        [Serializable]
+        public class InMemoryEvent : IEvent
+        {
+        }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>());
+            }
+
+            class EnsureOrdering : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.Specify(First<FirstHandler>.Then<SecondHandler>().AndThen<MyEventHandler1>().AndThen<MyEventHandler2>());
+                }
+            }
+
+            class FirstHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                
+                public IBus Bus { get; set; }
+                
+                public void Handle(SomeMessage message)
+                {
+                    Context.FirstHandlerInvoked = true;
+
+                    Bus.InMemory.Raise<InMemoryEvent>(m => { });
+
+                }
+            }
+
+            class SecondHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                
+                public void Handle(SomeMessage message)
+                {
+                    Context.SecondHandlerInvoked = true;
+                }
+            }
+
+            class MyEventHandler1 : IHandleMessages<InMemoryEvent>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+
+                public void Handle(InMemoryEvent messageThatIsEnlisted)
+                {
+                    Bus.DoNotContinueDispatchingCurrentMessageToHandlers();
+
+                    Context.InMemoryEventReceivedByHandler1 = true;
+                }
+            }
+
+            class MyEventHandler2 : IHandleMessages<InMemoryEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(InMemoryEvent messageThatIsEnlisted)
+                {
+                    Context.InMemoryEventReceivedByHandler2 = true;
+                }
+            }
+        }
+    }
+#pragma warning restore  612, 618
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.InMemory
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+    public class When_raising_an_in_memory_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_delivered_to_handlers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<InMemoryEndpoint>(b => b.Given((bus, c) => bus.SendLocal<SomeCommand>(m => { })))
+                    .Done(c => c.WasInMemoryEventReceivedByHandler1 && c.WasInMemoryEventReceivedByHandler2)
+                    .Run();
+
+            Assert.True(context.WasInMemoryEventReceivedByHandler1, "class MyEventHandler1 did not receive the in-memory event");
+            Assert.True(context.WasInMemoryEventReceivedByHandler2, "class MyEventHandler2 did not receive the in-memory event");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasInMemoryEventReceivedByHandler1 { get; set; }
+            public bool WasInMemoryEventReceivedByHandler2 { get; set; }
+
+        }
+
+        public class InMemoryEndpoint : EndpointConfigurationBuilder
+        {
+            public InMemoryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>());
+            }
+
+            public class CommandHandler : IHandleMessages<SomeCommand>
+            {
+                public IBus Bus { get; set; }
+                public void Handle(SomeCommand messageThatIsEnlisted)
+                {
+                    Bus.InMemory.Raise<MyInMemoryEvent>(m => { });
+                }
+            }
+
+            public class MyEventHandler1 : IHandleMessages<MyInMemoryEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyInMemoryEvent messageThatIsEnlisted)
+                {
+                    Context.WasInMemoryEventReceivedByHandler1 = true;
+                }
+            }
+
+            public class MyEventHandler2 : IHandleMessages<MyInMemoryEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyInMemoryEvent messageThatIsEnlisted)
+                {
+                    Context.WasInMemoryEventReceivedByHandler2 = true;
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class SomeCommand : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MyInMemoryEvent : IEvent
+        {
+        }
+    }
+#pragma warning restore  612, 618
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event_from_a_non_handler.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event_from_a_non_handler.cs
@@ -1,0 +1,78 @@
+﻿namespace NServiceBus.AcceptanceTests.InMemory
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+
+    public class When_raising_an_in_memory_event_from_a_non_handler : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_delivered_to_handlers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<InMemoryEndpoint>()
+                    .Done(c => c.WasInMemoryEventReceivedByHandler1)
+                    .Run();
+
+            Assert.True(context.WasInMemoryEventReceivedByHandler1, "class MyEventHandler1 did not receive the in-memory event");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasInMemoryEventReceivedByHandler1 { get; set; }
+      
+        }
+
+        public class InMemoryEndpoint : EndpointConfigurationBuilder
+        {
+            public InMemoryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>());
+            }
+
+            public class StartUpRunner : IWantToRunWhenBusStartsAndStops
+            {
+                public IBus Bus { get; set; }
+              
+                public void Start()
+                {
+                    Bus.InMemory.Raise<MyInMemoryEvent>(m => m.SetHeader("MyHeader","MyValue"));      
+                }
+
+                public void Stop()
+                {
+                }
+            }
+
+            public class MyEventHandler1 : IHandleMessages<MyInMemoryEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyInMemoryEvent message)
+                {
+                    Assert.AreEqual("MyValue",Headers.GetMessageHeader(message,"MyHeader"));
+                    Context.WasInMemoryEventReceivedByHandler1 = true;
+                }
+            }
+
+        }
+
+
+        [Serializable]
+        public class SomeCommand : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MyInMemoryEvent : IEvent
+        {
+        }
+    }
+#pragma warning restore  612, 618
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event_transport_mutators_should_not_be_called.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event_transport_mutators_should_not_be_called.cs
@@ -1,0 +1,77 @@
+﻿namespace NServiceBus.AcceptanceTests.InMemory
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using MessageMutator;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+    public class When_raising_an_in_memory_event_transport_mutators_should_not_be_called : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Ensure_transport_mutators_should_not_be_called()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<InMemoryEndpoint>(b => b.Given((bus, c) => bus.InMemory.Raise<MyInMemoryEvent>(m => { })))
+                .Run();
+
+            Assert.False(context.MutateIncomingCalled);
+            Assert.False(context.MutateOutGoingCalled);
+        }
+
+        class Mutator : IMutateTransportMessages, INeedInitialization
+        {
+            public Context Context { get; set; }
+
+            public void MutateIncoming(TransportMessage transportMessage)
+            {
+                Context.MutateIncomingCalled = true;
+            }
+
+            public void MutateOutgoing(object[] messages, TransportMessage transportMessage)
+            {
+                Context.MutateOutGoingCalled = true;
+            }
+
+            public void Init()
+            {
+                Configure.Component<Mutator>(DependencyLifecycle.InstancePerCall);
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MutateOutGoingCalled { get; set; }
+            public bool MutateIncomingCalled { get; set; }
+        }
+
+        public class InMemoryEndpoint : EndpointConfigurationBuilder
+        {
+            public InMemoryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>());
+            }
+
+        }
+
+        public class MyEventHandler : IHandleMessages<MyInMemoryEvent>
+        {
+            public Context Context { get; set; }
+
+            public void Handle(MyInMemoryEvent messageThatIsEnlisted)
+            {
+            }
+        }
+
+
+        [Serializable]
+        public class MyInMemoryEvent : IEvent
+        {
+        }
+    }
+#pragma warning restore  612, 618
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/Issue_1980.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/Issue_1980.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class Issue_1980 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new V1Message())))
+                    .Done(c => c.V2MessageReceived)
+                    .Run();
+
+            Assert.IsTrue(context.V2MessageReceived);
+            Assert.IsFalse(context.V1MessageReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool V1MessageReceived { get; set; }
+            public bool V2MessageReceived { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    c => c.Configurer.ConfigureComponent<MutateIncomingMessages>(DependencyLifecycle.InstancePerCall));
+            }
+
+            class MutateIncomingMessages : IMutateIncomingMessages
+            {
+                public object MutateIncoming(object message)
+                {
+                    if (message is V1Message)
+                    {
+                        return new V2Message();
+                    }
+
+                    return message;
+                }
+            }
+
+            class V2MessageHandler : IHandleMessages<V2Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V2Message message)
+                {
+                    Context.V2MessageReceived = true;
+                }
+            }
+
+            class V1MessageHandler : IHandleMessages<V1Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V1Message message)
+                {
+                    Context.V1MessageReceived = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class V1Message : ICommand
+        {
+        }
+
+        [Serializable]
+        public class V2Message : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/When_defining_outgoing_message_mutators.cs
@@ -1,0 +1,95 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_defining_outgoing_message_mutators : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_applied_to_outgoing_messages()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<OutgoingMutatorEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeMutated())))
+                    .Done(c => c.MessageProcessed)
+                    .Run();
+
+            Assert.True(context.TransportMutatorCalled);
+            Assert.True(context.MessageMutatorCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageProcessed { get; set; }
+            public bool TransportMutatorCalled { get; set; }
+            public bool MessageMutatorCalled { get; set; }
+        }
+
+        public class OutgoingMutatorEndpoint : EndpointConfigurationBuilder
+        {
+            public OutgoingMutatorEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+
+            class MyTransportMessageMutator:IMutateOutgoingTransportMessages,INeedInitialization
+            {
+                public void MutateOutgoing(object[] messages, TransportMessage transportMessage)
+                {
+                    transportMessage.Headers["TransportMutatorCalled"] = true.ToString();
+                }
+
+                public void Init()
+                {
+                    Configure.Component<MyTransportMessageMutator>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            class MyMessageMutator : IMutateOutgoingMessages, INeedInitialization
+            {
+
+             
+                public object MutateOutgoing(object message)
+                {
+                    Headers.SetMessageHeader(message,"MessageMutatorCalled","true");
+
+                    return message;
+                }
+
+                public void Init()
+                {
+                    Configure.Component<MyMessageMutator>(DependencyLifecycle.InstancePerCall);
+                }
+
+            }
+
+            class MessageToBeMutatedHandler : IHandleMessages<MessageToBeMutated>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+
+                public void Handle(MessageToBeMutated message)
+                {
+                    Context.TransportMutatorCalled = Bus.CurrentMessageContext.Headers.ContainsKey("TransportMutatorCalled");
+                    Context.MessageMutatorCalled = Bus.CurrentMessageContext.Headers.ContainsKey("MessageMutatorCalled");
+
+                    Context.MessageProcessed = true;
+
+                }
+            }
+
+        }
+
+        [Serializable]
+        public class MessageToBeMutated : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/When_outgoing_mutator_replaces_message_instance.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/When_outgoing_mutator_replaces_message_instance.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_outgoing_mutator_replaces_message_instance : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_sent_should_be_new_instance()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new V1Message())))
+                .Done(c => c.V2MessageReceived)
+                .Run();
+
+            Assert.IsTrue(context.V2MessageReceived);
+            Assert.IsFalse(context.V1MessageReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool V1MessageReceived { get; set; }
+            public bool V2MessageReceived { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    c => c.Configurer.ConfigureComponent<MutateOutgoingMessages>(DependencyLifecycle.InstancePerCall));
+            }
+
+            class MutateOutgoingMessages : IMutateOutgoingMessages
+            {
+                public object MutateOutgoing(object message)
+                {
+                    if (message is V1Message)
+                    {
+                        return new V2Message();
+                    }
+
+                    return message;
+                }
+            }
+
+            class V2MessageHandler : IHandleMessages<V2Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V2Message message)
+                {
+                    Context.V2MessageReceived = true;
+                }
+            }
+
+            class V1MessageHandler : IHandleMessages<V1Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V1Message message)
+                {
+                    Context.V1MessageReceived = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class V1Message : ICommand
+        {
+        }
+
+        [Serializable]
+        public class V2Message : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
@@ -1,0 +1,27 @@
+namespace NServiceBus.AcceptanceTests
+{
+    using AcceptanceTesting.Customization;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Base class for all the NSB test that sets up our conventions
+    /// </summary>
+    [TestFixture]
+// ReSharper disable once PartialTypeWithSinglePart
+    public abstract partial class NServiceBusAcceptanceTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            Conventions.EndpointNamingConvention= t =>
+                {
+                    var baseNs = typeof (NServiceBusAcceptanceTest).Namespace;
+                    var testName = GetType().Name;
+                    return t.FullName.Replace(baseNs + ".", "").Replace(testName + "+", "")
+                            + "." + System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(testName).Replace("_", "");
+                };
+
+            Conventions.DefaultRunDescriptor = () => ScenarioDescriptors.Transports.Default;
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/FilteringWhatGetsAudited.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/FilteringWhatGetsAudited.cs
@@ -1,0 +1,138 @@
+﻿
+namespace NServiceBus.AcceptanceTests.PipelineExtension
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Audit;
+    using NUnit.Framework;
+    using Pipeline;
+    using Pipeline.Contexts;
+
+    /// <summary>
+    /// This is a demo on how pipeline overrides can be used to control which messages that gets audited by NServiceBus
+    /// </summary>
+    public class FilteringWhatGetsAudited : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void RunDemo()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<UserEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                .WithEndpoint<AuditSpy>()
+                .Done(c => c.IsMessageHandlingComplete)
+                .Run();
+
+            Assert.IsFalse(context.MessageAudited);
+        }
+
+
+        public class UserEndpoint : EndpointConfigurationBuilder
+        {
+
+            public UserEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<AuditSpy>();
+
+            }
+
+            class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+                }
+            }
+
+#pragma warning disable 618
+            class MyFilteringAuditBehavior : IBehavior<ReceivePhysicalMessageContext>,
+                IBehavior<ReceiveLogicalMessageContext>
+            {
+                public MessageAuditer MessageAuditer { get; set; }
+
+                public void Invoke(ReceivePhysicalMessageContext context, Action next)
+                {
+                    var auditResult = new AuditFilterResult();
+                    context.Set(auditResult);
+                    next();
+
+                    //note: and rule operating on the raw TransportMessage can be applied here if needed.
+                    // Access to the message is through: context.PhysicalMessage. Eg:  context.PhysicalMessage.Headers.ContainsKey("NServiceBus.ControlMessage")
+                    if (auditResult.DoNotAuditMessage)
+                    {
+                        return;
+                    }
+                    MessageAuditer.ForwardMessageToAuditQueue(context.PhysicalMessage);
+                }
+
+                public void Invoke(ReceiveLogicalMessageContext context, Action next)
+                {
+                    //filter out messages of type MessageToBeAudited
+                    if (context.LogicalMessage.MessageType == typeof(MessageToBeAudited))
+                    {
+                        context.Get<AuditFilterResult>().DoNotAuditMessage = true;
+                    }
+                }
+
+                class AuditFilterResult
+                {
+                    public bool DoNotAuditMessage { get; set; }
+                }
+
+
+                //here we inject our behavior
+                class AuditFilteringOverride : PipelineOverride
+                {
+                    public override void Override(BehaviorList<ReceivePhysicalMessageContext> behaviorList)
+                    {
+                        //we replace the default audit behavior with out own
+                        behaviorList.Replace<AuditBehavior, MyFilteringAuditBehavior>();
+                    }
+
+                    public override void Override(BehaviorList<ReceiveLogicalMessageContext> behaviorList)
+                    {
+                        //and also hook into to logical receive pipeline to make filtering on message types easier
+                        behaviorList.Add<MyFilteringAuditBehavior>();
+                    }
+                }
+
+#pragma warning restore 618
+            }
+        }
+
+        public class AuditSpy : EndpointConfigurationBuilder
+        {
+
+            public AuditSpy()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.MessageAudited = true;
+                }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsMessageHandlingComplete { get; set; }
+            public bool MessageAudited { get; set; }
+        }
+
+
+        [Serializable]
+        public class MessageToBeAudited : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/MutingHandlerExceptions.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/MutingHandlerExceptions.cs
@@ -1,0 +1,121 @@
+﻿
+namespace NServiceBus.AcceptanceTests.PipelineExtension
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using Pipeline;
+    using Pipeline.Contexts;
+    using Unicast.Behaviors;
+
+    /// <summary>
+    /// This is a demo on how pipeline overrides can be used to control which messages that gets audited by NServiceBus
+    /// </summary>
+    public class MutingHandlerExceptions : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void RunDemo()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<EndpointWithCustomExceptionMuting>(b => b.Given(bus => bus.SendLocal(new MessageThatWillBlowUpButExWillBeMuted())))
+                .WithEndpoint<AuditSpy>()
+                .Done(c => c.IsMessageHandlingComplete)
+                .Run();
+
+            Assert.IsTrue(context.MessageAudited);
+        }
+
+
+        public class EndpointWithCustomExceptionMuting : EndpointConfigurationBuilder
+        {
+
+            public EndpointWithCustomExceptionMuting()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<AuditSpy>();
+
+            }
+
+            class Handler : IHandleMessages<MessageThatWillBlowUpButExWillBeMuted>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageThatWillBlowUpButExWillBeMuted message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+
+                    throw new Exception("Lets filter on this text");
+                }
+            }
+
+#pragma warning disable 618
+            class MyExceptionFilteringBehavior : IBehavior<HandlerInvocationContext>
+            {
+                public void Invoke(HandlerInvocationContext context, Action next)
+                {
+                    try
+                    {
+                        //invoke the handler/rest of the pipeline
+                        next();
+                    }
+                    //catch specifix exceptions or
+                    catch (Exception ex)
+                    {
+                        //modify this to your liking
+                        if (ex.Message == "Lets filter on this text")
+                            return;
+
+                        throw;
+                    }
+                }
+
+
+                //here we inject our behavior
+                class MyExceptionFilteringOverride : PipelineOverride
+                {
+                    public override void Override(BehaviorList<HandlerInvocationContext> behaviorList)
+                    {
+                        //add our behavior to the pipeline just before NSB actually calls the handlers
+                        behaviorList.InsertBefore<InvokeHandlersBehavior, MyExceptionFilteringBehavior>();
+                    }
+                }
+
+#pragma warning restore 618
+
+            }
+        }
+
+        public class AuditSpy : EndpointConfigurationBuilder
+        {
+
+            public AuditSpy()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AuditMessageHandler : IHandleMessages<MessageThatWillBlowUpButExWillBeMuted>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageThatWillBlowUpButExWillBeMuted message)
+                {
+                    MyContext.MessageAudited = true;
+                }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsMessageHandlingComplete { get; set; }
+            public bool MessageAudited { get; set; }
+        }
+
+
+        [Serializable]
+        public class MessageThatWillBlowUpButExWillBeMuted : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/SkipDeserialization.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/SkipDeserialization.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.AcceptanceTests.PipelineExtension
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using Pipeline;
+    using Pipeline.Contexts;
+    using Unicast.Messages;
+
+    //This is a demo on how the pipeline overrides can be used to create endpoints that doesn't deserialize incoming messages and there by
+    // allows the user to handle the raw transport message. This replaces the old feature on the UnicastBus where SkipDeserialization could be set to tru
+    public class SkipDeserialization : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void RunDemo()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonSerializingEndpoint>(
+                        b => b.Given(bus => bus.SendLocal(new SomeMessage())))
+                    .Done(c => c.GotTheRawMessage)
+                    .Run();
+        }
+
+        public class NonSerializingEndpoint : EndpointConfigurationBuilder
+        {
+            public NonSerializingEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+
+#pragma warning disable 618
+            //first we override the default "extraction" behavior
+            class MyOverride : PipelineOverride
+            {
+                public override void Override(BehaviorList<ReceivePhysicalMessageContext> behaviorList)
+                {
+                    behaviorList.Replace<ExtractLogicalMessagesBehavior, MyRawMessageHandler>();
+                }
+            }
+
+            //and then we handle the physical message our self
+            class MyRawMessageHandler:IBehavior<ReceivePhysicalMessageContext>
+            {
+                public Context Context { get; set; }
+
+                public void Invoke(ReceivePhysicalMessageContext context, Action next)
+                {
+                    var transportMessage = context.PhysicalMessage;
+
+                    Assert.True(transportMessage.Headers[Headers.EnclosedMessageTypes].Contains(typeof(SomeMessage).Name));
+
+                    Context.GotTheRawMessage = true;
+                }
+            }
+#pragma warning restore 618
+
+            class ThisHandlerWontGetInvoked:IHandleMessages<SomeMessage>
+            {
+                public void Handle(SomeMessage message)
+                {
+                    Assert.Fail();
+                }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheRawMessage { get; set; }
+        }
+
+        [Serializable]
+        public class SomeMessage : ICommand
+        {
+
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/Subscriptions.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/Subscriptions.cs
@@ -1,0 +1,24 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using Features;
+    using Unicast.Subscriptions;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
+    [Serializable]
+    public class Subscriptions
+    {
+        public static Action<Action<SubscriptionEventArgs>> OnEndpointSubscribed = actionToPerform =>
+            {
+                if (Feature.IsEnabled<MessageDrivenSubscriptions>())
+                {
+                    Configure.Instance.Builder.Build<MessageDrivenSubscriptionManager>().ClientSubscribed +=
+                        (sender, args) =>
+                        {
+                            actionToPerform(args);
+                        };
+                }
+            };
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_multi_subscribing_to_a_polymorphic_event.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_multi_subscribing_to_a_polymorphic_event.cs
@@ -1,0 +1,127 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_multi_subscribing_to_a_polymorphic_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Both_events_should_be_delivered()
+        {
+            var rootContext = new Context();
+
+            Scenario.Define(rootContext)
+                    .WithEndpoint<Publisher1>(b => b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(args =>
+                {
+                    if (args.MessageType.Contains(typeof(IMyEvent).Name))
+                    {
+                        context.SubscribedToIMyEvent = true;
+                    }
+
+                    if (args.MessageType.Contains(typeof(MyEvent2).Name))
+                    {
+                        context.SubscribedToMyEvent2 = true;
+                    }
+                }))
+                    .When(c => c.SubscribedToIMyEvent && c.SubscribedToMyEvent2, bus => bus.Publish(new MyEvent1())))
+                    .WithEndpoint<Publisher2>(b => b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(args =>
+                {
+                    if (args.MessageType.Contains(typeof(IMyEvent).Name))
+                    {
+                        context.SubscribedToIMyEvent = true;
+                    }
+
+                    if (args.MessageType.Contains(typeof(MyEvent2).Name))
+                    {
+                        context.SubscribedToMyEvent2 = true;
+                    }
+                }))
+                    .When(c => c.SubscribedToIMyEvent && c.SubscribedToMyEvent2, bus => bus.Publish(new MyEvent2())))
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                    {
+                        bus.Subscribe<IMyEvent>();
+                        bus.Subscribe<MyEvent2>();
+
+                        if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                        {
+                            context.SubscribedToIMyEvent = true;
+                            context.SubscribedToMyEvent2 = true;
+                        }
+                    }))
+                    .Done(c => c.SubscriberGotIMyEvent && c.SubscriberGotMyEvent2)
+                    .Run();
+
+            Assert.True(rootContext.SubscriberGotIMyEvent);
+            Assert.True(rootContext.SubscriberGotMyEvent2);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SubscriberGotIMyEvent { get; set; }
+            public bool SubscriberGotMyEvent2 { get; set; }
+            public bool SubscribedToIMyEvent { get; set; }
+            public bool SubscribedToMyEvent2 { get; set; }
+        }
+
+        public class Publisher1 : EndpointConfigurationBuilder
+        {
+            public Publisher1()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Publisher2 : EndpointConfigurationBuilder
+        {
+            public Publisher2()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<IMyEvent>(typeof(Publisher1))
+                    .AddMapping<MyEvent2>(typeof(Publisher2));
+            }
+
+            public class MyEventHandler : IHandleMessages<IMyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(IMyEvent messageThatIsEnlisted)
+                {
+                    if (messageThatIsEnlisted is MyEvent2)
+                    {
+                        Context.SubscriberGotMyEvent2 = true;
+                    }
+                    else
+                    {
+                        Context.SubscriberGotIMyEvent = true;
+                    }
+                }
+            }
+        }
+
+        
+        [Serializable]
+        public class MyEvent1 : IMyEvent
+        {
+        }
+
+        [Serializable]
+        public class MyEvent2 : IMyEvent
+        {
+        }
+
+        public interface IMyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event.cs
@@ -1,0 +1,166 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_an_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Issue_1851()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                        {
+                            if (s.SubscriberReturnAddress.Queue.Contains("Subscriber3"))
+                            {
+                                context.Subscriber3Subscribed = true;
+                            }
+                        }))
+                        .When(c => c.Subscriber3Subscribed, bus => bus.Publish<IFoo>())
+                     )
+                    .WithEndpoint<Subscriber3>(b => b.Given((bus, context) =>
+                    {
+                        bus.Subscribe<IFoo>();
+
+                        if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                        {
+                            context.Subscriber3Subscribed = true;
+                        }
+                    }))
+                      
+                    .Done(c => c.Subscriber3GotTheEvent)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.Subscriber3GotTheEvent))
+                    .Run();
+        }
+
+        [Test]
+        public void Should_be_delivered_to_all_subscribers()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                        {
+                            if (s.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                                context.Subscriber1Subscribed = true;
+
+                            if (s.SubscriberReturnAddress.Queue.Contains("Subscriber2"))
+                                context.Subscriber2Subscribed = true;
+                        }))
+                        .When(c => c.Subscriber1Subscribed && c.Subscriber2Subscribed, bus => bus.Publish(new MyEvent()))
+                     )
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<MyEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.Subscriber1Subscribed = true;
+                        }))
+                      .WithEndpoint<Subscriber2>(b => b.Given((bus, context) =>
+                      {
+                          bus.Subscribe<MyEvent>();
+
+                          if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                              context.Subscriber2Subscribed = true;
+                      }))
+                    .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c =>
+                    {
+                        Assert.True(c.Subscriber1GotTheEvent);
+                        Assert.True(c.Subscriber2GotTheEvent);
+                    })
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+            public bool Subscriber2GotTheEvent { get; set; }
+            public bool Subscriber3GotTheEvent { get; set; }
+            public bool Subscriber1Subscribed { get; set; }
+            public bool Subscriber2Subscribed { get; set; }
+            public bool Subscriber3Subscribed { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber3 : EndpointConfigurationBuilder
+        {
+            public Subscriber3()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<IFoo>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<IFoo>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(IFoo messageThatIsEnlisted)
+                {
+                    Context.Subscriber3GotTheEvent = true;
+                }
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                        .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber2GotTheEvent = true;
+                }
+            }
+        }
+
+        public interface IFoo : IEvent
+        {
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_using_a_broker_transport_with_centralized_routing.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_using_a_broker_transport_with_centralized_routing.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_an_event_using_a_broker_transport_with_centralized_routing : NServiceBusAcceptanceTest
+    {
+        [Test, Ignore] // Ignore because, test this test is unreliable. Passed on the build server without the core fix!
+        public void Should_be_delivered_to_allsubscribers_without_the_need_for_config()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<CentralizedPublisher>
+                    (b => b.When(c => c.IsSubscriptionProcessedForSub1 && c.IsSubscriptionProcessedForSub2, bus => bus.Publish(new MyEvent())))
+                    .WithEndpoint<CentralizedSubscriber1>(b => b.Given((bus, context) =>
+                    {
+                      context.IsSubscriptionProcessedForSub1 = true;
+                    }))
+                    .WithEndpoint<CentralizedSubscriber2>(b => b.Given((bus, context) =>
+                    {
+                        context.IsSubscriptionProcessedForSub2 = true;
+                    }))
+                    .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
+                    .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())
+                    .Should(c =>
+                    {
+                        Assert.True(c.Subscriber1GotTheEvent);
+                        Assert.True(c.Subscriber2GotTheEvent);
+                    })
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+            public bool Subscriber2GotTheEvent { get; set; }
+
+            public bool IsSubscriptionProcessedForSub1 { get; set; }
+            public bool IsSubscriptionProcessedForSub2 { get; set; }
+        }
+
+        public class CentralizedPublisher : EndpointConfigurationBuilder
+        {
+            public CentralizedPublisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class CentralizedSubscriber1 : EndpointConfigurationBuilder
+        {
+            public CentralizedSubscriber1()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        public class CentralizedSubscriber2 : EndpointConfigurationBuilder
+        {
+            public CentralizedSubscriber2()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber2GotTheEvent = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_only_local_messagehandlers.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_only_local_messagehandlers.cs
@@ -1,0 +1,104 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_an_event_with_only_local_messagehandlers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_trigger_the_catch_all_handler_for_message_driven_subscriptions()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<MessageDrivenPublisher>(b =>
+                                             b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                                                 {
+                                                     context.LocalEndpointSubscribed = true;
+                                                 }))
+                                              .When(c => c.LocalEndpointSubscribed, bus => bus.Publish(new EventHandledByLocalEndpoint()))
+                )
+                    .Done(c => c.CatchAllHandlerGotTheMessage)
+                    .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                    .Should(c => Assert.True(c.CatchAllHandlerGotTheMessage))
+
+                    .Run();
+        }
+
+        [Test]
+        public void Should_trigger_the_catch_all_handler_for_publishers_with_centralized_pubsub()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<CentralizedStoragePublisher>(b => b.When(c => c.EndpointsStarted, (bus, context) => bus.Publish(new EventHandledByLocalEndpoint())))
+                    .Done(c => c.CatchAllHandlerGotTheMessage)
+                    .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>(Transports.ActiveMQ)) //exclude active since the support for polymorphic routing is not implemented
+                    .Should(c => Assert.True(c.CatchAllHandlerGotTheMessage))
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            
+            public bool CatchAllHandlerGotTheMessage { get; set; }
+
+            public bool LocalEndpointSubscribed { get; set; }
+        }
+
+        public class MessageDrivenPublisher : EndpointConfigurationBuilder
+        {
+            public MessageDrivenPublisher()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<EventHandledByLocalEndpoint>(typeof(MessageDrivenPublisher)); //an explicit mapping is needed
+            }
+
+            class CatchAllHandler:IHandleMessages<IEvent> //not enough for auto subscribe to work
+            {
+                public Context Context { get; set; }
+                public void Handle(IEvent message)
+                {
+                    Context.CatchAllHandlerGotTheMessage = true;
+                }
+            }
+
+            class DummyHandler : IHandleMessages<EventHandledByLocalEndpoint> //explicit handler for the event is needed
+            {
+                public Context Context { get; set; }
+                public void Handle(EventHandledByLocalEndpoint message)
+                {
+                }
+            }
+        }
+
+        public class CentralizedStoragePublisher : EndpointConfigurationBuilder
+        {
+            public CentralizedStoragePublisher()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.AutoSubscribe(s => s.DoNotRequireExplicitRouting()));
+            }
+
+            class CatchAllHandler : IHandleMessages<IEvent> 
+            {
+                public Context Context { get; set; }
+                public void Handle(IEvent message)
+                {
+                    Context.CatchAllHandlerGotTheMessage = true;
+                }
+            }
+
+            class DummyHandler : IHandleMessages<EventHandledByLocalEndpoint> //explicit handler for the event is needed
+            {
+                public Context Context { get; set; }
+                public void Handle(EventHandledByLocalEndpoint message)
+                {
+                }
+            }
+        }
+        [Serializable]
+        public class EventHandledByLocalEndpoint : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_overridden_local_address.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_overridden_local_address.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_an_event_with_overridden_local_address : NServiceBusAcceptanceTest
+    {
+        [Test, Explicit("This test fails against RabbitMQ")]
+        public void Should_be_delivered_to_all_subscribers()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher>(b =>
+                        b.Given((bus, context) =>
+                            Subscriptions.OnEndpointSubscribed(s =>
+                            {
+                                if (s.SubscriberReturnAddress.Queue.Contains("myinputqueue"))
+                                    context.Subscriber1Subscribed = true;
+                            }))
+                        .When(c => c.Subscriber1Subscribed, bus => bus.Publish(new MyEvent()))
+                     )
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<MyEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.Subscriber1Subscribed = true;
+                        }))
+                    .Done(c => c.Subscriber1GotTheEvent)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.Subscriber1GotTheEvent))
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+            public bool Subscriber1Subscribed { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class OverrideLocalAddress : IWantToRunBeforeConfiguration
+            {
+                public void Init()
+                {
+                    Address.InitializeLocalAddress("myinputqueue");
+                }
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_the_subscriber_scaled_out.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_the_subscriber_scaled_out.cs
@@ -1,0 +1,119 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+    using Unicast.Subscriptions;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
+    public class When_publishing_an_event_with_the_subscriber_scaled_out : NServiceBusAcceptanceTest
+    {
+        static string Server1 = "Server1";
+        static string Server2 = "Server2";
+
+        [Test]//https://github.com/NServiceBus/NServiceBus/issues/1101
+        public void Should_only_publish_one_event()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                            {
+                                if (s.SubscriberReturnAddress.Queue != "MyEndpoint")
+                                    return;
+
+                                context.NumberOfSubscriptionsReceived++;
+                            }))
+                        .When(c => c.NumberOfSubscriptionsReceived >= 2, (bus, c) =>
+                            {
+                                c.SubscribersOfTheEvent = Configure.Instance.Builder.Build<ISubscriptionStorage>()
+                                                                  .GetSubscriberAddressesForMessage(new[] { new MessageType(typeof(MyEvent)) }).Select(a => a.ToString()).ToList();
+                            })
+                     )
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<MyEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.NumberOfSubscriptionsReceived++;
+                        }))
+                      .WithEndpoint<Subscriber2>(b => b.Given((bus, context) =>
+                      {
+                          bus.Subscribe<MyEvent>();
+
+                          if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                              context.NumberOfSubscriptionsReceived++;
+                      }))
+                    .Done(c => c.SubscribersOfTheEvent != null)
+                    .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>(Transports.Msmq)
+                        .For<AllSubscriptionStorages>(SubscriptionStorages.Msmq))
+                    .Should(c => Assert.AreEqual(1, c.SubscribersOfTheEvent.Count(), "There should only be one logical subscriber"))
+                    .MaxTestParallelism(1)//we force the endpoint names so we can't run this is parallel
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int NumberOfSubscriptionsReceived { get; set; }
+
+            public IEnumerable<string> SubscribersOfTheEvent { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<MyEvent>(typeof (Publisher))
+                    .CustomMachineName(Server1)
+                    .CustomEndpointName("MyEndpoint");
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                }
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                        .AddMapping<MyEvent>(typeof(Publisher))
+                        .CustomMachineName(Server2)
+                        .CustomEndpointName("MyEndpoint");
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_subscribing_to_a_base_event_from_different_publishers.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_subscribing_to_a_base_event_from_different_publishers.cs
@@ -1,0 +1,113 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_subscribing_to_a_base_event_from_different_publishers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void should_receive_events_from_all_publishers()
+        {
+            var cc = new Context();
+
+            Scenario.Define(cc)
+               .WithEndpoint<Publisher1>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                        {
+                            if (s.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                                context.SubscribedToPublisher1 = true;
+                        }))
+                        .When(c => c.SubscribedToPublisher1, bus => bus.Publish(new DerivedEvent1()))
+                     )
+                .WithEndpoint<Publisher2>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                        {
+                            if (s.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                                context.SubscribedToPublisher2 = true;
+                        }))
+                        .When(c => c.SubscribedToPublisher2, bus => bus.Publish(new DerivedEvent2()))
+                     )
+               .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+               {
+                   if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                   {
+                       context.SubscribedToPublisher1 = true;
+                       context.SubscribedToPublisher2 = true;
+                   }
+               }))
+               .Done(c => c.GotTheEventFromPublisher1 && c.GotTheEventFromPublisher2)
+               .Run();
+
+            Assert.True(cc.GotTheEventFromPublisher1);
+            Assert.True(cc.GotTheEventFromPublisher2);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheEventFromPublisher1 { get; set; }
+            public bool GotTheEventFromPublisher2 { get; set; }
+            public bool SubscribedToPublisher1 { get; set; }
+            public bool SubscribedToPublisher2 { get; set; }
+
+        }
+
+        public class Publisher1 : EndpointConfigurationBuilder
+        {
+            public Publisher1()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Publisher2 : EndpointConfigurationBuilder
+        {
+            public Publisher2()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Enable<AutoSubscribe>())
+                    .AddMapping<DerivedEvent1>(typeof(Publisher1))
+                    .AddMapping<DerivedEvent2>(typeof(Publisher2));
+            }
+
+            public class BaseEventHandler : IHandleMessages<BaseEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(BaseEvent message)
+                {
+                    if (message.GetType().FullName.Contains("DerivedEvent1"))
+                        Context.GotTheEventFromPublisher1 = true;
+                    if (message.GetType().FullName.Contains("DerivedEvent2"))
+                        Context.GotTheEventFromPublisher2 = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class BaseEvent : IEvent
+        {
+        }
+
+        [Serializable]
+        public class DerivedEvent1 : BaseEvent
+        {
+
+        }
+
+        [Serializable]
+        public class DerivedEvent2 : BaseEvent
+        {
+
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_subscribing_to_a_polymorphic_event.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_subscribing_to_a_polymorphic_event.cs
@@ -1,0 +1,124 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
+    public class When_subscribing_to_a_polymorphic_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Event_should_be_delivered()
+        {
+            var cc = new Context();
+
+            Scenario.Define(cc)
+                    .WithEndpoint<Publisher>(b => b.Given((bus, context) => EnableNotificationsOnSubscribe(context))
+                    .When(c => c.Subscriber1Subscribed && c.Subscriber2Subscribed, bus => bus.Publish(new MyEvent())))
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<IMyEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.Subscriber1Subscribed = true;
+                        }))
+                    .WithEndpoint<Subscriber2>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<MyEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.Subscriber2Subscribed = true;
+                        }))
+                    .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
+                    .Run();
+
+            Assert.True(cc.Subscriber1GotTheEvent);
+            Assert.True(cc.Subscriber2GotTheEvent);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+
+            public bool Subscriber2GotTheEvent { get; set; }
+
+            public int NumberOfSubscribers { get; set; }
+
+            public bool Subscriber1Subscribed { get; set; }
+
+            public bool Subscriber2Subscribed { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c=>Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<IMyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<IMyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(IMyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                        .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber2GotTheEvent = true;
+                }
+            }
+        }
+        static void EnableNotificationsOnSubscribe(Context context)
+        {
+            if (Feature.IsEnabled<MessageDrivenSubscriptions>())
+            {
+                Configure.Instance.Builder.Build<MessageDrivenSubscriptionManager>().ClientSubscribed +=
+                    (sender, args) =>
+                    {
+                        if (args.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                            context.Subscriber1Subscribed = true;
+
+                        if (args.SubscriberReturnAddress.Queue.Contains("Subscriber2"))
+                            context.Subscriber2Subscribed = true;
+                    };
+            }
+        }
+
+        [Serializable]
+        public class MyEvent : IMyEvent
+        {
+        }
+
+        public interface IMyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Retries/When_doing_flr_with_default_settings.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Retries/When_doing_flr_with_default_settings.cs
@@ -1,0 +1,135 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using Config;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_doing_flr_with_default_settings : NServiceBusAcceptanceTest
+    {
+        public static Func<int> X = () => 5;
+            
+        [Test]
+        public void Should_do_X_retries_by_default_with_dtc_on()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried{ Id = context.Id })))
+                    .Done(c => c.HandedOverToSlr || c.NumberOfTimesInvoked > X())
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c => Assert.AreEqual(X(), c.NumberOfTimesInvoked, string.Format("The FLR should by default retry {0} times", X())))
+                    .Run();
+
+        }
+
+        [Test]
+        public void Should_do_X_retries_by_default_with_native_transactions()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<RetryEndpoint>(b =>
+                        {
+                            b.CustomConfig(c => Configure.Transactions.Advanced(a => a.DisableDistributedTransactions()));
+                            b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried { Id = context.Id }));
+                        })
+                    .Done(c => c.HandedOverToSlr || c.NumberOfTimesInvoked > X())
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.AreEqual(X(), c.NumberOfTimesInvoked, string.Format("The FLR should by default retry {0} times", X())))
+                    .Run(TimeSpan.FromMinutes(X()));
+
+        }
+
+        [Test]
+        public void Should_not_do_any_retries_if_transactions_are_off()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<RetryEndpoint>(b =>
+                    {
+                        b.CustomConfig(c => Configure.Transactions.Disable());
+                        b.Given((bus, context) =>
+                            {
+                                bus.SendLocal(new MessageToBeRetried { Id = context.Id });
+                                bus.SendLocal(new MessageToBeRetried { Id = context.Id, SecondMessage = true });
+                            });
+                    })
+                    .Done(c => c.SecondMessageReceived || c.NumberOfTimesInvoked > 1)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.AreEqual(1, c.NumberOfTimesInvoked, "No retries should be in use if transactions are off"))
+                    .Run();
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public int NumberOfTimesInvoked { get; set; }
+
+            public bool HandedOverToSlr { get; set; }
+
+            public bool SecondMessageReceived { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    c => c.Configurer.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance))
+                    .WithConfig<TransportConfig>(c => c.MaximumConcurrencyLevel = 1)
+                    .AllowExceptions();
+            }
+
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.HandedOverToSlr = true;
+                }
+
+                public void Init(Address address)
+                {
+
+                }
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageToBeRetried message)
+                {
+                    if (message.Id != Context.Id) return; // messages from previous test runs must be ignored
+
+                    if (message.SecondMessage)
+                    {
+                        Context.SecondMessageReceived = true;
+                        return;
+                    }
+
+                    Context.NumberOfTimesInvoked++;
+
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid Id { get; set; }
+
+            public bool SecondMessage { get; set; }
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Retries/When_message_fails_with_retries_set_to_0.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Retries/When_message_fails_with_retries_set_to_0.cs
@@ -1,0 +1,87 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using System.Collections.Generic;
+    using Config;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_message_fails_with_retries_set_to_0 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_retry_the_message_using_flr()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                    .Done(c => c.HandedOverToSlr)
+                    .Run();
+
+            Assert.AreEqual(1, context.NumberOfTimesInvoked,"No FLR should be in use if MaxRetries is set to 0");
+            Assert.True(context.HeadersOfTheFailedMessage[Headers.ProcessingEndpoint].Contains("RetryEndpoint"), "The receiver should attach its endpoint name as a header");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int NumberOfTimesInvoked { get; set; }
+
+            public bool HandedOverToSlr { get; set; }
+
+            public Dictionary<string, string> HeadersOfTheFailedMessage { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Configurer.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance))
+                    .WithConfig<TransportConfig>(c =>
+                        {
+                            c.MaxRetries = 0;
+                        })
+                        .AllowExceptions();
+            }
+
+            class CustomFaultManager: IManageMessageFailures
+            {
+                public Context  Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+                    
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.HandedOverToSlr = true;
+                    Context.HeadersOfTheFailedMessage = message.Headers;
+                }
+
+                public void Init(Address address)
+                {
+                    
+                }
+            }
+
+            class MessageToBeRetriedHandler:IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+                public void Handle(MessageToBeRetried message)
+                {
+                    Context.NumberOfTimesInvoked++;
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Retries/When_messages_fails_flr.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Retries/When_messages_fails_flr.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_messages_fails_flr : NServiceBusAcceptanceTest
+    {
+        static TimeSpan SlrDelay = TimeSpan.FromSeconds(5);
+
+        [Test]
+        public void Should_be_moved_to_slr()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<SLREndpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried { Id = context.Id })))
+                    .Done(c => c.NumberOfTimesInvoked >= 2)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(context =>
+                        {
+                            Assert.GreaterOrEqual(1,context.NumberOfSlrRetriesPerformed, "The SLR should only do one retry");
+                            Assert.GreaterOrEqual(context.TimeOfSecondAttempt - context.TimeOfFirstAttempt,SlrDelay , "The SLR should delay the retry");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public int NumberOfTimesInvoked { get; set; }
+
+            public DateTime TimeOfFirstAttempt { get; set; }
+            public DateTime TimeOfSecondAttempt { get; set; }
+
+            public int NumberOfSlrRetriesPerformed { get; set; }
+        }
+
+        public class SLREndpoint : EndpointConfigurationBuilder
+        {
+            public SLREndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AllowExceptions()
+                    .WithConfig<TransportConfig>(c =>
+                        {
+                            c.MaxRetries = 0; //to skip the FLR
+                        })
+                        .WithConfig<SecondLevelRetriesConfig>(c =>
+                        {
+                            c.NumberOfRetries = 1;
+                            c.TimeIncrease = SlrDelay;
+                        });
+            }
+
+
+            class MessageToBeRetriedHandler:IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MessageToBeRetried message)
+                {
+                    if (message.Id != Context.Id) return; // ignore messages from previous test runs
+
+                    Context.NumberOfTimesInvoked++;
+
+                    if (Context.NumberOfTimesInvoked == 1)
+                        Context.TimeOfFirstAttempt = DateTime.UtcNow;
+
+                    if (Context.NumberOfTimesInvoked == 2)
+                    {
+                        Context.TimeOfSecondAttempt = DateTime.UtcNow;
+                    }
+
+                    Context.NumberOfSlrRetriesPerformed = int.Parse(Bus.CurrentMessageContext.Headers[Headers.Retries]); 
+                        
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Retries/When_sending_a_message_off_to_slr.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Retries/When_sending_a_message_off_to_slr.cs
@@ -1,0 +1,146 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using System.Linq;
+    using Config;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+
+    public class When_sending_a_message_off_to_slr : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_preserve_the_original_body_for_regular_exceptions()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                    .Done(c => c.SlrChecksum != default(byte))
+                    .Run();
+
+            Assert.AreEqual(context.OriginalBodyChecksum, context.SlrChecksum, "The body of the message sent to slr should be the same as the original message coming off the queue");
+
+        }
+        [Test]
+        public void Should_preserve_the_original_body_for_serialization_exceptions()
+        {
+            var context = new Context
+                {
+                    SimulateSerializationException = true
+                };
+
+            Scenario.Define(context)
+                    .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                    .Done(c => c.SlrChecksum != default(byte))
+                    .Run();
+
+            Assert.AreEqual(context.OriginalBodyChecksum, context.SlrChecksum, "The body of the message sent to slr should be the same as the original message coming off the queue");
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public byte OriginalBodyChecksum { get; set; }
+
+            public byte SlrChecksum { get; set; }
+
+            public bool SimulateSerializationException { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Configurer.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance))
+                    .WithConfig<TransportConfig>(c =>
+                        {
+                            c.MaxRetries = 0;
+                        })
+                        .AllowExceptions();
+            }
+
+            class BodyMutator : IMutateTransportMessages, NServiceBus.INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+
+                    var originalBody = transportMessage.Body;
+
+                    Context.OriginalBodyChecksum = Checksum(originalBody);
+
+                    var decryptedBody = new byte[originalBody.Length];
+
+                    Buffer.BlockCopy(originalBody,0,decryptedBody,0,originalBody.Length);
+                   
+                    //decrypt
+                    decryptedBody[0]++;
+
+                    if (Context.SimulateSerializationException)
+                        decryptedBody[1]++;
+
+                    transportMessage.Body = decryptedBody;
+                }
+
+
+                public void MutateOutgoing(object[] messages, TransportMessage transportMessage)
+                {
+                    transportMessage.Body[0]--;
+                }
+
+                public void Init()
+                {
+                    Configure.Component<BodyMutator>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+                    Context.SlrChecksum = Checksum(message.Body);
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.SlrChecksum = Checksum(message.Body);
+                }
+
+                public void Init(Address address)
+                {
+
+                }
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public void Handle(MessageToBeRetried message)
+                {
+                    throw new Exception("Simulated exception");
+                }
+            }
+
+            public static byte Checksum(byte[] data)
+            {
+                var longSum = data.Sum(x => (long)x);
+                return unchecked((byte)longSum);
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+        }
+    }
+
+#pragma warning restore  612, 618
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/Issue_1819.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/Issue_1819.cs
@@ -1,0 +1,118 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class Issue_1819 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context { Id = Guid.NewGuid() };
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new StartSaga1 { ContextId = c.Id })))
+                    .Done(c => (c.Saga1TimeoutFired && c.Saga2TimeoutFired) || c.SagaNotFound)
+                    .Run(TimeSpan.FromSeconds(20));
+
+            Assert.IsFalse(context.SagaNotFound);
+            Assert.IsTrue(context.Saga1TimeoutFired);
+            Assert.IsTrue(context.Saga2TimeoutFired);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public bool Saga1TimeoutFired { get; set; }
+            public bool Saga2TimeoutFired { get; set; }
+            public bool SagaNotFound { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>, IHandleTimeouts<Saga2Timeout>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga1 message)
+                {
+                    if (message.ContextId != Context.Id) return;
+
+                    RequestTimeout(TimeSpan.FromSeconds(5), new Saga1Timeout { ContextId = Context.Id });
+                    RequestTimeout(new DateTime(2011, 10, 14, 23, 08, 0, DateTimeKind.Local), new Saga2Timeout { ContextId = Context.Id });
+                }
+
+                public void Timeout(Saga1Timeout state)
+                {
+                    MarkAsComplete();
+
+                    if (state.ContextId != Context.Id) return;
+                    Context.Saga1TimeoutFired = true;
+                }
+
+                public void Timeout(Saga2Timeout state)
+                {
+                    if (state.ContextId != Context.Id) return;
+                    Context.Saga2TimeoutFired = true;
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                }
+            }
+
+            public class SagaNotFound : IHandleSagaNotFound
+            {
+                public Context Context { get; set; }
+
+                public void Handle(object message)
+                {
+                    if (((dynamic)message).ContextId != Context.Id) return;
+
+                    Context.SagaNotFound = true;
+                }
+            }
+
+            public class CatchAllMessageHandler : IHandleMessages<object>
+            {
+                public void Handle(object message)
+                {
+
+                }
+            }
+
+            public class Foo : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.SpecifyFirst<CatchAllMessageHandler>();
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+            public Guid ContextId { get; set; }
+        }
+
+
+        public class Saga1Timeout
+        {
+            public Guid ContextId { get; set; }
+        }
+
+        public class Saga2Timeout
+        {
+            public Guid ContextId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/Issue_2044.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/Issue_2044.cs
@@ -1,0 +1,99 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class Issue_2044 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MessageToSaga())))
+                    .WithEndpoint<ReceiverWithSaga>()
+                    .Done(c => c.ReplyReceived)
+                    .Run();
+
+            Assert.IsTrue(context.ReplyReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool ReplyReceived { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MessageToSaga>(typeof(ReceiverWithSaga));
+            }
+
+            public class ReplyHandler : IHandleMessages<Reply>
+            {
+                public Context Context { get; set; }
+
+
+                public void Handle(Reply message)
+                {
+                    Context.ReplyReceived = true;
+                }
+            }
+        }
+
+        public class ReceiverWithSaga : EndpointConfigurationBuilder
+        {
+            public ReceiverWithSaga()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageToSaga>
+            {
+
+                public void Handle(StartSaga1 message)
+                {
+                }
+
+                public void Handle(MessageToSaga message)
+                {
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                }
+            }
+
+            public class SagaNotFound : IHandleSagaNotFound
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(object message)
+                {
+                    Bus.Reply(new Reply());
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MessageToSaga : ICommand
+        {
+        }
+
+        [Serializable]
+        public class Reply : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_a_saga_is_started_by_an_event_published_by_another_saga.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_a_saga_is_started_by_an_event_published_by_another_saga.cs
@@ -1,0 +1,217 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using PubSub;
+    using Saga;
+    using ScenarioDescriptors;
+
+    //Repro for #1323
+    public class When_a_saga_is_started_by_an_event_published_by_another_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_start_the_saga_and_request_a_timeout()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SagaThatPublishesAnEvent>(b =>
+                                                            b.Given(
+                                                                (bus, context) =>
+                                                                Subscriptions.OnEndpointSubscribed(s =>
+                                                                    {
+                                                                        if (s.SubscriberReturnAddress.Queue.Contains("SagaThatIsStartedByTheEvent"))
+                                                                        {
+                                                                            context.IsEventSubscriptionReceived = true;
+                                                                        }
+                                                                    }))
+                                                             .When(c => c.IsEventSubscriptionReceived,
+                                                                   bus =>
+                                                                   bus.SendLocal(new StartSaga {DataId = Guid.NewGuid()}))
+                )
+                    .WithEndpoint<SagaThatIsStartedByTheEvent>(
+                        b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<SomethingHappenedEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.IsEventSubscriptionReceived = true;
+                        }))
+
+                    .Done(c => c.DidSaga1Complete && c.DidSaga2Complete)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSaga1Complete && c.DidSaga2Complete))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSaga1Complete { get; set; }
+            public bool DidSaga2Complete { get; set; }
+            public bool IsEventSubscriptionReceived { get; set; }
+        }
+
+
+        [Test]
+        [Ignore("Not stable")]
+        public void Should_start_the_saga_when_set_up_to_start_for_the_base_event()
+        {
+            Scenario.Define<SagaContext>()
+                 .WithEndpoint<SagaThatPublishesAnEvent>(b =>
+                                                         b.Given(
+                                                             (bus, context) =>
+                                                             Subscriptions.OnEndpointSubscribed(s =>
+                                                             {
+                                                                 if (s.SubscriberReturnAddress.Queue.Contains("SagaThatIsStartedByABaseEvent"))
+                                                                 {
+                                                                     context.IsEventSubscriptionReceived = true;
+                                                                 }
+                                                             }))
+                                                          .When(c => c.IsEventSubscriptionReceived,
+                                                                bus =>
+                                                                bus.Publish<SomethingHappenedEvent>(m=> { m.DataId = Guid.NewGuid(); }))
+             )
+                 .WithEndpoint<SagaThatIsStartedByABaseEvent>(
+                     b => b.Given((bus, context) =>
+                     {
+                         bus.Subscribe<BaseEvent>();
+
+                          if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                              context.IsEventSubscriptionReceived = true;
+                     }))
+                 .Done(c => c.DidSagaComplete)
+                 .Repeat(r => r.For(Transports.Default))
+                 .Should(c => Assert.True(c.DidSagaComplete))
+                 .Run(TimeSpan.FromMinutes(3));
+        }
+
+        public class SagaContext : ScenarioContext
+        {
+            public bool IsEventSubscriptionReceived { get; set; }
+            public bool DidSagaComplete { get; set; }
+        }
+
+        public class SagaThatPublishesAnEvent : EndpointConfigurationBuilder
+        {
+            public SagaThatPublishesAnEvent()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>());
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga>, IHandleTimeouts<Saga1.Timeout1>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    Data.DataId = message.DataId;
+
+                    //Publish the event, which will start the second saga
+                    Bus.Publish<SomethingHappenedEvent>(m => { m.DataId = message.DataId; });
+
+                    //Request a timeout
+                    RequestTimeout<Timeout1>(TimeSpan.FromSeconds(5));
+                }
+
+                public void Timeout(Timeout1 state)
+                {
+                    MarkAsComplete();
+                    Context.DidSaga1Complete = true;
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+                public class Timeout1
+                {
+                }
+            }
+        }
+
+        public class SagaThatIsStartedByTheEvent : EndpointConfigurationBuilder
+        {
+            public SagaThatIsStartedByTheEvent()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<SomethingHappenedEvent>(typeof(SagaThatPublishesAnEvent));
+
+            }
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<SomethingHappenedEvent>, IHandleTimeouts<Saga2.Saga2Timeout>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(SomethingHappenedEvent message)
+                {
+                    Data.DataId = message.DataId;
+
+                    //Request a timeout
+                    RequestTimeout<Saga2Timeout>(TimeSpan.FromSeconds(5));
+                }
+
+                public void Timeout(Saga2Timeout state)
+                {
+                    MarkAsComplete();
+                    Context.DidSaga2Complete = true;
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+                public class Saga2Timeout
+                {
+                }
+            }
+        }
+
+        public class SagaThatIsStartedByABaseEvent : EndpointConfigurationBuilder
+        {
+            public SagaThatIsStartedByABaseEvent()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<BaseEvent>(typeof(SagaThatPublishesAnEvent));
+            }
+
+            public class SagaStartedByBaseEvent : Saga<SagaStartedByBaseEvent.SagaData>, IAmStartedByMessages<BaseEvent>
+            {
+                public SagaContext Context { get; set; }
+
+                public void Handle(BaseEvent message)
+                {
+                    Data.DataId = message.DataId;
+                    MarkAsComplete();
+                    Context.DidSagaComplete = true;
+                }
+
+                public class SagaData : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public interface SomethingHappenedEvent : BaseEvent
+        {
+          
+        }
+
+        public interface BaseEvent : IEvent
+        {
+            Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
@@ -1,0 +1,97 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    //repro for issue: https://github.com/NServiceBus/NServiceBus/issues/1020
+    public class When_a_saga_message_goes_through_the_slr : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_invoke_the_correct_handle_methods_on_the_saga()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid() })))
+                    .Done(c => c.SecondMessageProcessed)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SecondMessageProcessed { get; set; }
+
+
+            public int NumberOfTimesInvoked { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AllowExceptions();
+            }
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>,IHandleMessages<SecondSagaMessage>
+            {
+                public Context Context { get; set; }
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+
+                    Bus.SendLocal(new SecondSagaMessage
+                        {
+                            SomeId = Data.SomeId
+                        });
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSagaMessage>(m=>m.SomeId)
+                        .ToSaga(s=>s.SomeId);
+                    ConfigureMapping<SecondSagaMessage>(m => m.SomeId)
+                      .ToSaga(s => s.SomeId);
+                }
+
+                public void Handle(SecondSagaMessage message)
+                {
+                    Context.NumberOfTimesInvoked++;
+                    var shouldFail = Context.NumberOfTimesInvoked < 2; //1 FLR and 1 SLR
+
+                    if(shouldFail)
+                        throw new Exception("Simulated exception");
+
+                    Context.SecondMessageProcessed = true;
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+        public class SecondSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+        
+        public class SomeTimeout
+        {
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
@@ -1,0 +1,108 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    // Repro for issue  https://github.com/NServiceBus/NServiceBus/issues/1277 to test the fix
+    // making sure that the saga correlation still works.
+    public class When_an_endpoint_replies_to_a_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_correlate_all_saga_messages_properly()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointThatHostsASaga>(b => b.Given(bus => bus.SendLocal(new StartSaga { DataId = Guid.NewGuid() })))
+                    .WithEndpoint<EndpointThatHandlesAMessageFromSagaAndReplies>()
+                    .Done(c => c.DidSagaReplyMessageGetCorrelated)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSagaReplyMessageGetCorrelated))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSagaReplyMessageGetCorrelated { get; set; }
+        }
+
+        public class EndpointThatHandlesAMessageFromSagaAndReplies : EndpointConfigurationBuilder
+        {
+            public EndpointThatHandlesAMessageFromSagaAndReplies()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class DoSomethingHandler : IHandleMessages<DoSomething>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(DoSomething message)
+                {
+                    Console.WriteLine("Received DoSomething command for DataId:{0} ... and responding with a reply", message.DataId);
+                    Bus.Reply(new DoSomethingResponse { DataId = message.DataId });
+                }
+            }
+        }
+
+        public class EndpointThatHostsASaga : EndpointConfigurationBuilder
+        {
+            public EndpointThatHostsASaga()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<DoSomething>(typeof (EndpointThatHandlesAMessageFromSagaAndReplies));
+
+            }
+
+            public class Saga2 : Saga<Saga2.MySaga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<DoSomethingResponse>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    var dataId = Guid.NewGuid();
+                    Console.Out.WriteLine("Saga2 sending DoSomething for DataId: {0}", dataId);
+                    Data.DataId = dataId;
+                    Bus.Send(new DoSomething { DataId = dataId });
+                }
+
+                public void Handle(DoSomethingResponse message)
+                {
+                    Context.DidSagaReplyMessageGetCorrelated = message.DataId == Data.DataId;
+                    Console.Out.WriteLine("Saga received DoSomethingResponse for DataId: {0} and MarkAsComplete", message.DataId);
+                    MarkAsComplete();
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySaga2Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+            }
+        }
+        
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class DoSomething : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class DoSomethingResponse : IMessage
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
@@ -1,0 +1,104 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_doing_request_response_between_sagas : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_autocorrelate_the_response_back_to_the_requesting_saga()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new InitiateRequestingSaga { DataId = Guid.NewGuid() })))
+                    .Done(c => c.DidRequestingSagaGetTheResponse)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidRequestingSagaGetTheResponse))
+                    .Run(TimeSpan.FromSeconds(20));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidRequestingSagaGetTheResponse { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class RequestingSaga : Saga<RequestingSaga.RequestingSagaData>, 
+                IAmStartedByMessages<InitiateRequestingSaga>, 
+                IHandleMessages<ResponseFromOtherSaga>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(InitiateRequestingSaga message)
+                {
+                    Data.DataId = message.DataId;
+                    Bus.SendLocal(new RequestToRespondingSaga { DataId = message.DataId });
+                }
+
+                public void Handle(ResponseFromOtherSaga message)
+                {
+                    Context.DidRequestingSagaGetTheResponse = true;
+                    MarkAsComplete();
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<InitiateRequestingSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+                public class RequestingSagaData : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+            }
+
+            public class RespondingSaga : Saga<RespondingSaga.RespondingSagaData>, 
+                IAmStartedByMessages<RequestToRespondingSaga>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(RequestToRespondingSaga message)
+                {
+                    Bus.Reply(new ResponseFromOtherSaga { DataId = message.DataId });
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                }
+
+                public class RespondingSagaData : ContainSagaData
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class InitiateRequestingSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        [Serializable]
+        public class RequestToRespondingSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        [Serializable]
+        public class ResponseFromOtherSaga : IMessage
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
@@ -1,0 +1,95 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Saga;
+    using NUnit.Framework;
+
+    public class When_message_has_a_saga_id : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_start_a_new_saga_if_not_found()
+        {
+            var context = Scenario.Define<Context>()
+                .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                {
+                    var message = new MessageWithSagaId();
+
+                    bus.SetMessageHeader(message, Headers.SagaId, Guid.NewGuid().ToString());
+                    bus.SetMessageHeader(message, Headers.SagaType, typeof(MySaga).AssemblyQualifiedName);
+
+                    bus.SendLocal(message);
+                }))
+                .Done(c => c.NotFoundHandlerCalled && c.OtherSagaStarted)
+                .Run(TimeSpan.FromSeconds(15));
+
+            Assert.True(context.NotFoundHandlerCalled);
+            Assert.True(context.OtherSagaStarted);
+            Assert.False(context.MessageHandlerCalled);
+            Assert.False(context.TimeoutHandlerCalled);
+        }
+
+        class MySaga : Saga<MySaga.SagaData>, IAmStartedByMessages<MessageWithSagaId>,
+            IHandleTimeouts<MessageWithSagaId>,
+            IHandleSagaNotFound
+        {
+            public Context Context { get; set; }
+
+            public class SagaData : ContainSagaData
+            {
+            }
+
+            public void Handle(MessageWithSagaId message)
+            {
+                Context.MessageHandlerCalled = true;
+            }
+
+            public void Handle(object message)
+            {
+                Context.NotFoundHandlerCalled = true;
+            }
+
+            public void Timeout(MessageWithSagaId state)
+            {
+                Context.TimeoutHandlerCalled = true;
+            }
+        }
+
+        class MyOtherSaga : Saga<MyOtherSaga.SagaData>, IAmStartedByMessages<MessageWithSagaId>
+        {
+            public Context Context { get; set; }
+
+            public void Handle(MessageWithSagaId message)
+            {
+                Context.OtherSagaStarted = true;
+            }
+
+            public class SagaData : ContainSagaData
+            {
+            }
+
+        }
+
+
+        class Context : ScenarioContext
+        {
+            public bool NotFoundHandlerCalled { get; set; }
+            public bool MessageHandlerCalled { get; set; }
+            public bool TimeoutHandlerCalled { get; set; }
+            public bool OtherSagaStarted { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class MessageWithSagaId : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_is_mapped_to_an_existing_saga_instance.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_is_mapped_to_an_existing_saga_instance.cs
@@ -1,0 +1,89 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_that_is_mapped_to_an_existing_saga_instance : NServiceBusAcceptanceTest
+    {
+        static Guid IdThatSagaIsCorrelatedOn = Guid.NewGuid();
+
+        [Test]
+        public void Should_hydrate_and_invoke_the_existing_instance()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                        {
+                            bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn });
+                            bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn, SecondMessage = true });                                    
+                        }))
+                    .Done(c => c.SecondMessageReceived)
+                    .Repeat(r => r.For(SagaPersisters.Default))
+                    .Should(c => Assert.AreEqual(c.FirstSagaInstance, c.SecondSagaInstance, "The same saga instance should be invoked invoked for both messages"))
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SecondMessageReceived { get; set; }
+
+            public Guid FirstSagaInstance { get; set; }
+            public Guid SecondSagaInstance { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c=>Configure.Transactions.Advanced(a => a.DoNotWrapHandlersExecutionInATransactionScope()));
+            }
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>
+            {
+                public Context Context { get; set; }
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+
+                    if (message.SecondMessage)
+                    {
+                        Context.SecondSagaInstance = Data.Id;
+                        Context.SecondMessageReceived = true;
+                    }
+                    else
+                    {
+                        Context.FirstSagaInstance = Data.Id;
+                    }
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSagaMessage>(m=>m.SomeId)
+                        .ToSaga(s=>s.SomeId);
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+
+                [Unique]
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+
+            public bool SecondMessage { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_should_complete_saga.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_should_complete_saga.cs
@@ -1,0 +1,141 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_that_completes_the_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_hydrate_and_complete_the_existing_instance()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<SagaEndpoint>(b =>
+                        {
+                            b.Given((bus, context) => bus.SendLocal(new StartSagaMessage {SomeId = context.Id}));
+                            b.When(context => context.StartSagaMessageReceived, (bus, context) => bus.SendLocal(new CompleteSagaMessage { SomeId = context.Id }));
+                        })
+                    .Done(c => c.SagaCompleted)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.IsNull(c.UnhandledException))
+
+                    .Run();
+        }
+
+        [Test]
+        public void Should_ignore_messages_afterwards()
+        {
+            Scenario.Define(() => new Context {Id = Guid.NewGuid()})
+                      .WithEndpoint<SagaEndpoint>(b =>
+                      {
+                          b.Given((bus, context) => bus.SendLocal(new StartSagaMessage { SomeId = context.Id }));
+                          b.When(context => context.StartSagaMessageReceived, (bus, context) => bus.SendLocal(new CompleteSagaMessage { SomeId = context.Id }));
+                          b.When(context => context.SagaCompleted, (bus, context) => bus.SendLocal(new AnotherMessage { SomeId = context.Id }));
+                      })
+                    .Done(c => c.AnotherMessageReceived)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c =>
+                        {
+                            Assert.IsNull(c.UnhandledException);
+                            Assert.False(c.SagaReceivedAnotherMessage,"AnotherMessage should not be delivered to the saga after completion");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Exception UnhandledException { get; set; }
+            public Guid Id { get; set; }
+
+            public bool StartSagaMessageReceived { get; set; }
+
+            public bool SagaCompleted { get; set; }
+
+            public bool AnotherMessageReceived { get; set; }
+            public bool SagaReceivedAnotherMessage { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    c => c.RavenSagaPersister().UnicastBus().LoadMessageHandlers<First<TestSaga>>());
+            }
+
+          
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>, IHandleMessages<CompleteSagaMessage>, IHandleMessages<AnotherMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+
+                    Context.StartSagaMessageReceived = true;
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSagaMessage>(m=>m.SomeId)
+                        .ToSaga(s=>s.SomeId);
+                    ConfigureMapping<CompleteSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                    ConfigureMapping<AnotherMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                }
+
+                public void Handle(CompleteSagaMessage message)
+                {
+                    MarkAsComplete();
+                    Context.SagaCompleted = true;
+                }
+
+                public void Handle(AnotherMessage message)
+                {
+                    Context.SagaReceivedAnotherMessage = true;
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+                [Unique]
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        public class CompletionHandler : IHandleMessages<AnotherMessage>
+        {
+            public Context Context { get; set; }
+            public void Handle(AnotherMessage message)
+            {
+                Context.AnotherMessageReceived = true;
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        [Serializable]
+        public class CompleteSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        [Serializable]
+        public class AnotherMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_should_start_a_saga.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_should_start_a_saga.cs
@@ -1,0 +1,101 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_that_should_start_a_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_start_the_saga_and_call_all_messagehandlers_for_the_given_message()
+        {
+            Scenario.Define<SagaEndpointContext>()
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage())))
+                    .Done(context => context.InterceptingHandlerCalled && context.SagaStarted)
+                    .Repeat(r => r.For<AllBuilders>())
+                    .Should(c =>
+                    {
+                        Assert.True(c.InterceptingHandlerCalled, "The message handler should be called");
+                        Assert.True(c.SagaStarted, "The saga should have been started");
+                    })
+                    .Run();
+        }
+
+
+        [Test]
+        public void Should_not_start_saga_if_a_interception_handler_has_been_invoked()
+        {
+            Scenario.Define(() => new SagaEndpointContext{InterceptSaga = true})
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage())))
+                   .Done(context => context.InterceptingHandlerCalled)
+                   .Repeat(r => r.For<AllBuilders>())
+                   .Should(c =>
+                        {
+                            Assert.True(c.InterceptingHandlerCalled, "The intercepting handler should be called");
+                            Assert.False(c.SagaStarted, "The saga should not have been started since the intercepting handler stops the pipeline");
+                        })
+                    .Run();
+        }
+
+
+        public class SagaEndpointContext : ScenarioContext
+        {
+            public bool InterceptingHandlerCalled { get; set; }
+
+            public bool SagaStarted { get; set; }
+
+            public bool InterceptSaga { get; set; }
+        }
+
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>c.UnicastBus().LoadMessageHandlers<First<InterceptingHandler>>());
+            }
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>
+            {
+                public SagaEndpointContext Context { get; set; }
+                public void Handle(StartSagaMessage message)
+                {
+                    Context.SagaStarted = true;
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+            }
+
+            public class InterceptingHandler : IHandleMessages<StartSagaMessage>
+            {
+                public SagaEndpointContext Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                    Context.InterceptingHandlerCalled = true;
+
+                    if(Context.InterceptSaga)
+                        Bus.DoNotContinueDispatchingCurrentMessageToHandlers();
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+        }
+
+
+    }
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
@@ -1,0 +1,105 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_sending_from_a_saga_handle : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_match_different_saga()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new StartSaga1 { DataId = Guid.NewGuid() })))
+                    .Done(c => c.DidSaga2ReceiveMessage)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSaga2ReceiveMessage))
+                    .Run(TimeSpan.FromSeconds(20));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSaga2ReceiveMessage { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageSaga1WillHandle>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga1 message)
+                {
+                    var dataId = Guid.NewGuid();
+                    Data.DataId = dataId;
+                    Bus.SendLocal(new MessageSaga1WillHandle
+                             {
+                                 DataId = dataId
+                             });
+                }
+
+                public void Handle(MessageSaga1WillHandle message)
+                {
+                    Bus.SendLocal(new StartSaga2());
+                    MarkAsComplete();
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<MessageSaga1WillHandle>(m => m.DataId).ToSaga(s => s.DataId);
+                    ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+            }
+
+            public class Saga1Data : ContainSagaData
+            {
+                [Unique]
+                public virtual Guid DataId { get; set; }
+            }
+
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartSaga2>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga2 message)
+                {
+                    Context.DidSaga2ReceiveMessage = true;
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                }
+            }
+
+        }
+
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+
+        [Serializable]
+        public class StartSaga2 : ICommand
+        {
+        }
+        public class MessageSaga1WillHandle : IMessage
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
@@ -1,0 +1,88 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_sending_from_a_saga_timeout : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_match_different_saga()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new StartSaga1())))
+                    .Done(c => c.DidSaga2ReceiveMessage)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSaga2ReceiveMessage))
+                    .Run(TimeSpan.FromSeconds(20));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSaga2ReceiveMessage { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga1 message)
+                {
+                    RequestTimeout(TimeSpan.FromSeconds(1), new Saga1Timeout());
+                }
+
+                public void Timeout(Saga1Timeout state)
+                {
+                    Bus.SendLocal(new StartSaga2());
+                    MarkAsComplete();
+                }
+                public class Saga1Data : ContainSagaData
+                {
+                }
+            }
+
+
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartSaga2>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga2 message)
+                {
+                    Context.DidSaga2ReceiveMessage = true;
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                }
+            }
+
+        }
+
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+        }
+
+        [Serializable]
+        public class StartSaga2 : ICommand
+        {
+        }
+
+        public class Saga1Timeout : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
@@ -1,0 +1,161 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using PubSub;
+    using Saga;
+    using ScenarioDescriptors;
+
+    // Repro for issue  https://github.com/NServiceBus/NServiceBus/issues/1277
+    public class When_two_sagas_subscribe_to_the_same_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_invoke_all_handlers_on_all_sagas()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointThatHostsTwoSagas>(b => 
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                        {
+                            if (s.SubscriberReturnAddress.Queue.Contains("Saga1"))
+                            {
+                                context.Subscribed = true;
+                            }
+                        }))
+                        .When(c => true, bus => bus.SendLocal(new StartSaga2
+                        {
+                            DataId = Guid.NewGuid()
+                        }))
+                     )
+                    .WithEndpoint<EndpointThatHandlesAMessageAndPublishesEvent>()
+                    .Done(c => c.DidSaga1EventHandlerGetInvoked && c.DidSaga2EventHandlerGetInvoked)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSaga1EventHandlerGetInvoked && c.DidSaga2EventHandlerGetInvoked))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscribed { get; set; }
+            public bool DidSaga1EventHandlerGetInvoked { get; set; }
+            public bool DidSaga2EventHandlerGetInvoked { get; set; }
+        }
+
+        public class EndpointThatHandlesAMessageAndPublishesEvent : EndpointConfigurationBuilder
+        {
+            public EndpointThatHandlesAMessageAndPublishesEvent()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class OpenGroupCommandHandler : IHandleMessages<OpenGroupCommand>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(OpenGroupCommand message)
+                {
+                    Console.WriteLine("Received OpenGroupCommand for DataId:{0} ... and publishing GroupPendingEvent", message.DataId);
+                    Bus.Publish(new GroupPendingEvent { DataId = message.DataId });
+                }
+            }
+        }
+
+        public class EndpointThatHostsTwoSagas : EndpointConfigurationBuilder
+        {
+            public EndpointThatHostsTwoSagas()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<OpenGroupCommand>(typeof(EndpointThatHandlesAMessageAndPublishesEvent))
+                    .AddMapping<GroupPendingEvent>(typeof(EndpointThatHandlesAMessageAndPublishesEvent));
+            }
+
+            public class Saga1 : Saga<Saga1.MySaga1Data>, IAmStartedByMessages<GroupPendingEvent>, IHandleMessages<CompleteSaga1Now>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(GroupPendingEvent message)
+                {
+                    Data.DataId = message.DataId;
+                    Console.Out.WriteLine("Saga1 received GroupPendingEvent for DataId: {0}", message.DataId);
+                    Context.DidSaga1EventHandlerGetInvoked = true;
+                    Bus.SendLocal(new CompleteSaga1Now { DataId = message.DataId });
+                }
+
+                public void Handle(CompleteSaga1Now message)
+                {
+                    Console.Out.WriteLine("Saga1 received CompleteSaga1Now for DataId:{0} and MarkAsComplete", message.DataId);
+
+                    MarkAsComplete();
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<GroupPendingEvent>(m => m.DataId).ToSaga(s => s.DataId);
+                    ConfigureMapping<CompleteSaga1Now>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySaga1Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual  Guid DataId { get; set; }
+                }
+            }
+
+            public class Saga2 : Saga<Saga2.MySaga2Data>, IAmStartedByMessages<StartSaga2>, IHandleMessages<GroupPendingEvent>
+            {
+                public Context Context { get; set; }
+         
+                public void Handle(StartSaga2 message)
+                {
+                    var dataId = Guid.NewGuid();
+                    Console.Out.WriteLine("Saga2 sending OpenGroupCommand for DataId: {0}", dataId);
+                    Data.DataId = dataId;
+                    Bus.Send(new OpenGroupCommand { DataId = dataId });
+                }
+
+                public void Handle(GroupPendingEvent message)
+                {
+                    Context.DidSaga2EventHandlerGetInvoked = true;
+                    Console.Out.WriteLine("Saga2 received GroupPendingEvent for DataId: {0} and MarkAsComplete", message.DataId);
+                    MarkAsComplete();
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
+                    ConfigureMapping<GroupPendingEvent>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySaga2Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual  Guid DataId { get; set; }
+                }
+            }
+        }
+
+        [Serializable]
+        public class GroupPendingEvent : IEvent
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class OpenGroupCommand : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        [Serializable]
+        public class StartSaga2 : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class CompleteSaga1Now : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using PubSub;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_using_a_received_message_for_timeout : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Timeout_should_be_received_after_expiration()
+        {
+            Scenario.Define(() => new Context {Id = Guid.NewGuid()})
+                    .WithEndpoint<SagaEndpoint>(b =>
+                    {
+                        b.Given((bus, context) =>
+                        {
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                            {
+                                bus.SendLocal(new StartSagaMessage { SomeId = context.Id });
+                            }
+                            else
+                            {
+                                Subscriptions.OnEndpointSubscribed(s => bus.SendLocal(new StartSagaMessage { SomeId = context.Id }));
+                            }
+
+                        });
+
+                        b.When(context => context.StartSagaMessageReceived,
+                            (bus, context) => bus.Publish(new SomeEvent { SomeId = context.Id }));
+
+                    })
+                    .Done(c => c.TimeoutReceived)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public bool StartSagaMessageReceived { get; set; }
+
+            public bool SomeEventReceived { get; set; }
+
+            public bool TimeoutReceived { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.RavenSagaPersister()
+                                                   .UnicastBus())
+                    .AddMapping<SomeEvent>(typeof (SagaEndpoint));
+            }
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>,
+                                    IHandleMessages<SomeEvent>, IHandleTimeouts<SomeEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+                    Context.StartSagaMessageReceived = true;
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                    ConfigureMapping<SomeEvent>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                }
+
+                public void Handle(SomeEvent message)
+                {
+                    RequestTimeout(TimeSpan.FromMilliseconds(100), message);
+                    Context.SomeEventReceived = true;
+                }
+
+                public void Timeout(SomeEvent message)
+                {
+                    Context.TimeoutReceived = true;
+                    MarkAsComplete();
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+
+                [Unique]
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        [Serializable]
+        public class SomeEvent : IEvent
+        {
+            public Guid SomeId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    // Repro for #SB-191
+    public class When_using_contain_saga_data : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_handle_timeouts_properly()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointThatHostsASaga>(
+                        b => b.Given(bus => bus.SendLocal(new StartSaga {DataId = Guid.NewGuid()})))
+                    .Done(c => c.DidAllSagaInstancesReceiveTimeouts)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidAllSagaInstancesReceiveTimeouts))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidAllSagaInstancesReceiveTimeouts { get; set; }
+        }
+
+        public class EndpointThatHostsASaga : EndpointConfigurationBuilder
+        {
+            public EndpointThatHostsASaga()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MySaga : Saga<MySaga.MySagaData>,
+                                                             IAmStartedByMessages<StartSaga>,
+                                                             IHandleTimeouts<MySaga.TimeHasPassed>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    Data.DataId = message.DataId;
+
+                    RequestTimeout(TimeSpan.FromSeconds(5), new TimeHasPassed());
+                }
+
+                public void Timeout(TimeHasPassed state)
+                {
+                    MarkAsComplete();
+
+                    Context.DidAllSagaInstancesReceiveTimeouts = true;
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySagaData : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+                public class TimeHasPassed
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllBuilders.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllBuilders.cs
@@ -1,0 +1,17 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using AcceptanceTesting.Support;
+
+    public class AllBuilders : ScenarioDescriptor
+    {
+        public AllBuilders()
+        {
+            Add(Builders.Autofac);
+            Add(Builders.Windsor);
+            Add(Builders.Ninject);
+            Add(Builders.Spring);
+            Add(Builders.StructureMap);
+            Add(Builders.Unity);
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllSerializers.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllSerializers.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using AcceptanceTesting.Support;
+
+    public class AllSerializers : ScenarioDescriptor
+    {
+        public AllSerializers()
+        {
+            Add(Serializers.Bson);
+            Add(Serializers.Json);
+            Add(Serializers.Xml);
+            Add(Serializers.Binary);
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllSubscriptionStorages.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllSubscriptionStorages.cs
@@ -1,0 +1,14 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using AcceptanceTesting.Support;
+
+    public class AllSubscriptionStorages : ScenarioDescriptor
+    {
+        public AllSubscriptionStorages()
+        {
+            Add(SubscriptionStorages.InMemory);
+            Add(SubscriptionStorages.Raven);
+            Add(SubscriptionStorages.Msmq);
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllTransports.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllTransports.cs
@@ -1,0 +1,121 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using AcceptanceTesting.Support;
+    using Hosting.Helpers;
+    using NServiceBus.Transports;
+
+    public class AllTransports : ScenarioDescriptor
+    {
+        public AllTransports()
+        {
+            AddRange(ActiveTransports);
+        }
+
+        static IEnumerable<RunDescriptor> ActiveTransports
+        {
+            get
+            {
+                if (activeTransports == null)
+                {
+                    //temporary fix until we can get rid of the "AllTransports" all together
+                    activeTransports = new List<RunDescriptor>
+                    {
+                        Transports.Default
+                    }; 
+                }
+
+                return activeTransports;
+            }
+        }
+
+        static ICollection<RunDescriptor> activeTransports;
+    }
+
+    public class AllDtcTransports : AllTransports
+    {
+        public AllDtcTransports()
+        {
+            AllTransportsFilter.Run(t => t.HasSupportForDistributedTransactions.HasValue
+                                         && !t.HasSupportForDistributedTransactions.Value, Remove);
+
+            // todo set HasSupportForDistributedTransactions to false on Rabbit MQ
+            AllTransportsFilter.Run(t => t.GetType().Name.Contains("RabbitMQ"), Remove);
+        }
+    }
+
+    public class AllBrokerTransports : AllTransports
+    {
+        public AllBrokerTransports()
+        {
+            AllTransportsFilter.Run(t => !t.HasNativePubSubSupport, Remove);
+        }
+    }
+
+    public class AllTransportsWithCentralizedPubSubSupport : AllTransports
+    {
+        public AllTransportsWithCentralizedPubSubSupport()
+        {
+            AllTransportsFilter.Run(t => !t.HasSupportForCentralizedPubSub, Remove);
+        }
+    }
+
+    public class AllTransportsWithMessageDrivenPubSub : AllTransports
+    {
+        public AllTransportsWithMessageDrivenPubSub()
+        {
+            AllTransportsFilter.Run(t => t.HasNativePubSubSupport, Remove);
+        }
+    }
+
+    public class TypeScanner
+    {
+
+        public static IEnumerable<Type> GetAllTypesAssignableTo<T>()
+        {
+            return AvailableAssemblies.SelectMany(a => a.GetTypes())
+                                      .Where(t => typeof (T).IsAssignableFrom(t) && t != typeof(T))
+                                      .ToList();
+        }
+
+        static IEnumerable<Assembly> AvailableAssemblies
+        {
+            get
+            {
+                if (assemblies == null)
+                {
+                    var result = new AssemblyScanner().GetScannableAssemblies();
+
+                    assemblies = result.Assemblies;
+                }
+                    
+                return assemblies;
+            }
+        }
+
+        static List<Assembly> assemblies;
+    }
+
+    public static class AllTransportsFilter
+    {
+        public static void Run(Func<TransportDefinition, bool> condition, Func<RunDescriptor, bool> remove)
+        {
+            foreach (var rundescriptor in Transports.AllAvailable)
+            {
+                var transportAssemblyQualifiedName = rundescriptor.Settings["Transport"];
+                var type = Type.GetType(transportAssemblyQualifiedName);
+                if (type != null)
+                {
+                    var transport = Activator.CreateInstance(type) as TransportDefinition;
+                    if (condition(transport))
+                    {
+                        remove(rundescriptor);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Builders.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Builders.cs
@@ -1,0 +1,61 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using ObjectBuilder.Common;
+
+    public static class Builders
+    {
+        static IList<RunDescriptor> availableTransports;
+
+        public static IEnumerable<RunDescriptor> AllAvailable
+        {
+            get { return availableTransports ?? (availableTransports = GetAllAvailable().ToList()); }
+        }
+
+        static IEnumerable<RunDescriptor> GetAllAvailable()
+        {
+            var builders = TypeScanner.GetAllTypesAssignableTo<IContainer>()
+                .Where(t => !t.Assembly.FullName.StartsWith("NServiceBus.Core") && //exclude the default builder
+                            t.Name.EndsWith("ObjectBuilder") ) //exclude the ninject child container 
+                .ToList();
+
+            return from builder in builders let name = builder.Name.Replace("ObjectBuilder", "") select (new RunDescriptor
+            {
+                Key = name,
+                Settings = new Dictionary<string, string> { { "Builder", builder.AssemblyQualifiedName } }
+            });
+        }
+
+        public static RunDescriptor Autofac
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Autofac"); }
+        }
+
+        public static RunDescriptor Ninject
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Ninject"); }
+        }
+
+        public static RunDescriptor StructureMap
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "StructureMap"); }
+        }
+
+        public static RunDescriptor Windsor
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Windsor"); }
+        }
+
+        public static RunDescriptor Spring
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Spring"); }
+        }
+
+        public static RunDescriptor Unity
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Unity"); }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SagaPersisters.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SagaPersisters.cs
@@ -1,0 +1,61 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using Persistence.InMemory.SagaPersister;
+    using Persistence.Raven.SagaPersister;
+    using Saga;
+
+    public class SagaPersisters : ScenarioDescriptor
+    {
+        public SagaPersisters()
+        {
+            var persisters = AvailablePersisters;
+
+            foreach (var persister in persisters)
+            {
+                Add(new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string> { { "SagaPersister", persister.AssemblyQualifiedName } }
+                });
+            }
+        }
+
+        static List<Type> AvailablePersisters
+        {
+            get
+            {
+                var persisters = TypeScanner.GetAllTypesAssignableTo<ISagaPersister>()
+                    .Where(t => !t.IsInterface)
+                    .ToList();
+                return persisters;
+            }
+        }
+
+        public static RunDescriptor Default
+        {
+            get
+            {
+                var persisters = AvailablePersisters;
+                var persister = persisters.FirstOrDefault(p => p != typeof(InMemorySagaPersister) && p != typeof(RavenSagaPersister));
+
+                if (persister == null)
+                {
+                    persister = typeof(InMemorySagaPersister);
+                }
+
+                return new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string>
+                    {
+                        {"SagaPersister", persister.AssemblyQualifiedName}
+                    }
+                };
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Serializers.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Serializers.cs
@@ -1,0 +1,59 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System.Collections.Generic;
+    using AcceptanceTesting.Support;
+    using NServiceBus.Serializers.Binary;
+    using NServiceBus.Serializers.Json;
+    using NServiceBus.Serializers.XML;
+
+    public static class Serializers
+    {
+        public static readonly RunDescriptor Binary = new RunDescriptor
+            {
+                Key = "Binary",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (BinaryMessageSerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+        public static readonly RunDescriptor Bson = new RunDescriptor
+            {
+                Key = "Bson",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (BsonMessageSerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+        public static readonly RunDescriptor Xml = new RunDescriptor
+            {
+                Key = "Xml",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (XmlMessageSerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+        public static readonly RunDescriptor Json = new RunDescriptor
+            {
+                Key = "Json",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (JsonMessageSerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SubscriptionPersisters.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SubscriptionPersisters.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using Persistence.InMemory.SubscriptionStorage;
+    using Persistence.Msmq.SubscriptionStorage;
+    using Persistence.Raven.SubscriptionStorage;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
+    public class SubscriptionPersisters : ScenarioDescriptor
+    {
+        public SubscriptionPersisters()
+        {
+            var persisters = AvailablePersisters;
+
+            foreach (var persister in persisters)
+            {
+                Add(new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string> { { "SubscriptionStorage", persister.AssemblyQualifiedName } }
+                });
+            }
+        }
+
+        static List<Type> AvailablePersisters
+        {
+            get
+            {
+                var persisters = TypeScanner.GetAllTypesAssignableTo<ISubscriptionStorage>()
+                    .Where(t => !t.IsInterface)
+                    .ToList();
+                return persisters;
+            }
+        }
+
+        public static RunDescriptor Default
+        {
+            get
+            {
+                var persisters = AvailablePersisters;
+                var persister = persisters.FirstOrDefault(p => p != typeof(InMemorySubscriptionStorage) && p != typeof(RavenSubscriptionStorage) && p != typeof(MsmqSubscriptionStorage));
+
+                if (persister == null)
+                {
+                    persister = typeof(InMemorySubscriptionStorage);
+                }
+
+                return new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string>
+                    {
+                        {"SubscriptionStorage", persister.AssemblyQualifiedName}
+                    }
+                };
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SubscriptionStorages.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SubscriptionStorages.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System.Collections.Generic;
+    using AcceptanceTesting.Support;
+    using Persistence.InMemory.SubscriptionStorage;
+    using Persistence.Msmq.SubscriptionStorage;
+    using Persistence.Raven.SubscriptionStorage;
+
+    public static class SubscriptionStorages
+    {
+        public static readonly RunDescriptor InMemory = new RunDescriptor
+            {
+                Key = "InMemorySubscriptionStorage",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "SubscriptionStorage",
+                                typeof (InMemorySubscriptionStorage).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+
+        public static readonly RunDescriptor Raven = new RunDescriptor
+            {
+                Key = "RavenSubscriptionStorage",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "SubscriptionStorage",
+                                typeof (RavenSubscriptionStorage).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+      
+        public static readonly RunDescriptor Msmq = new RunDescriptor
+            {
+                Key = "MsmqSubscriptionStorage",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "SubscriptionStorage",
+                                typeof (MsmqSubscriptionStorage).AssemblyQualifiedName
+                            }
+                        }
+            };
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/TimeoutPersisters.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/TimeoutPersisters.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using Persistence.InMemory.TimeoutPersister;
+    using Persistence.Raven.TimeoutPersister;
+    using Timeout.Core;
+
+    public class TimeoutPersisters : ScenarioDescriptor
+    {
+        public TimeoutPersisters()
+        {
+            var persisters = AvailablePersisters;
+
+            foreach (var persister in persisters)
+            {
+                Add(new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string> { { "TimeoutPersister", persister.AssemblyQualifiedName } }
+                });
+            }
+        }
+
+        static List<Type> AvailablePersisters
+        {
+            get
+            {
+                var persisters = TypeScanner.GetAllTypesAssignableTo<IPersistTimeouts>()
+                    .Where(t => !t.IsInterface)
+                    .ToList();
+                return persisters;
+            }
+        }
+
+        public static RunDescriptor Default
+        {
+            get
+            {
+                var persisters = AvailablePersisters;
+                var persister = persisters.FirstOrDefault(p => p != typeof(InMemoryTimeoutPersistence) && p != typeof(RavenTimeoutPersistence));
+
+                if (persister == null)
+                {
+                    persister = typeof(InMemoryTimeoutPersistence);
+                }
+
+                return new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string>
+                    {
+                        {"TimeoutPersister", persister.AssemblyQualifiedName}
+                    }
+                };
+            }
+        }
+    }
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Transports.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Transports.cs
@@ -1,0 +1,114 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using NServiceBus.Transports;
+
+    public static class Transports
+    {
+        public static IEnumerable<RunDescriptor> AllAvailable
+        {
+            get
+            {
+                if (availableTransports == null)
+                {
+                    availableTransports = GetAllAvailable().ToList();
+                }
+
+                return availableTransports;
+            }
+        }
+
+
+        public static RunDescriptor Default
+        {
+            get
+            {
+                var specificTransport = Environment.GetEnvironmentVariable("Transport.UseSpecific");
+
+                if (!string.IsNullOrEmpty(specificTransport))
+                    return AllAvailable.Single(r => r.Key == specificTransport);
+
+                var transportsOtherThanMsmq = AllAvailable.Where(t => t != Msmq);
+
+                if (transportsOtherThanMsmq.Count() == 1)
+                    return transportsOtherThanMsmq.First();
+
+                return Msmq;
+            }
+        }
+
+        public static RunDescriptor ActiveMQ
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "ActiveMQ"); }
+        }
+
+        public static RunDescriptor Msmq
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Msmq"); }
+        }
+
+        public static RunDescriptor RabbitMQ
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "RabbitMQ"); }
+        }
+
+
+
+        public static RunDescriptor SqlServer
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "SqlServer"); }
+        }
+
+        static IEnumerable<RunDescriptor> GetAllAvailable()
+        {
+            var foundTransportDefinitions = TypeScanner.GetAllTypesAssignableTo<TransportDefinition>();
+
+            
+            foreach (var transportDefinitionType in foundTransportDefinitions)
+            {
+                var key = transportDefinitionType.Name;
+
+                var runDescriptor = new RunDescriptor
+                {
+                    Key = key,
+                    Settings =
+                        new Dictionary<string, string>
+                                {
+                                    {"Transport", transportDefinitionType.AssemblyQualifiedName}
+                                }
+                };
+
+                var connectionString = Environment.GetEnvironmentVariable(key + ".ConnectionString");
+
+                if (string.IsNullOrEmpty(connectionString) && DefaultConnectionStrings.ContainsKey(key))
+                    connectionString = DefaultConnectionStrings[key];
+
+
+                if (!string.IsNullOrEmpty(connectionString))
+                {
+                    runDescriptor.Settings.Add("Transport.ConnectionString", connectionString);
+                    yield return runDescriptor;
+                }
+                else
+                {
+                    Console.Out.WriteLine("No connection string found for transport: {0}, test will not be executed for this transport", key);
+                }
+            }
+        }
+
+        static IList<RunDescriptor> availableTransports;
+
+        static readonly Dictionary<string, string> DefaultConnectionStrings = new Dictionary<string, string>
+            {
+                {"RabbitMQ", "host=localhost"},
+                {"SqlServer", @"Server=localhost\sqlexpress;Database=nservicebus;Trusted_Connection=True;"},
+                {"ActiveMQ", @"ServerUrl=activemq:tcp://localhost:61616"},
+                {"Msmq", @"cacheSendConnection=false;journal=false;"}
+            };
+
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Scheduling/When_scheduling_a_recurring_task.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Scheduling/When_scheduling_a_recurring_task.cs
@@ -1,0 +1,55 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_scheduling_a_recurring_task : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_execute_the_task()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SchedulingEndpoint>()
+                    .Done(c => c.ScheduleActionInvoked)
+                    .Repeat(r => r.For(Transports.Default))
+                  .Run(TimeSpan.FromSeconds(60));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool ScheduleActionInvoked { get; set; }
+        }
+
+        public class SchedulingEndpoint : EndpointConfigurationBuilder
+        {
+            public SchedulingEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class SetupScheduledAction : IWantToRunWhenBusStartsAndStops
+            {
+                public void Start()
+                {
+                    Schedule.Every(TimeSpan.FromSeconds(5))
+                       .Action("MyTask", () =>
+                       {
+                           Console.Out.WriteLine("Task invoked");
+                           Configure.Instance.Builder.Build<Context>()
+                                    .ScheduleActionInvoked = true;
+                       });
+                }
+
+                public void Stop()
+                {
+
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/OutdatedTimeoutPersister.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/OutdatedTimeoutPersister.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.Timeout.Core;
+
+    class OutdatedTimeoutPersister : IPersistTimeouts
+    {
+        public List<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+        {
+            nextTimeToRunQuery = DateTime.Now.AddYears(42);
+            return Enumerable.Empty<Tuple<string, DateTime>>().ToList();
+        }
+
+        public void Add(TimeoutData timeout)
+        {
+        }
+
+        public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+        {
+            timeoutData = null;
+            return false;
+        }
+
+        public void RemoveTimeoutBy(Guid sagaId)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/UpdatedTimeoutPersister.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/UpdatedTimeoutPersister.cs
@@ -1,0 +1,40 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.Timeout.Core;
+
+    class UpdatedTimeoutPersister : IPersistTimeouts, IPersistTimeoutsV2
+    {
+        public List<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+        {
+            nextTimeToRunQuery = DateTime.Now.AddYears(42);
+            return Enumerable.Empty<Tuple<string, DateTime>>().ToList();
+        }
+
+        public void Add(TimeoutData timeout)
+        {
+        }
+
+        public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+        {
+            timeoutData = null;
+            return false;
+        }
+
+        public void RemoveTimeoutBy(Guid sagaId)
+        {
+        }
+
+        public TimeoutData Peek(string timeoutId)
+        {
+            return null;
+        }
+
+        public bool TryRemove(string timeoutId)
+        {
+            return true;
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_dispatched_timeout_already_removed_from_timeout_storage.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_dispatched_timeout_already_removed_from_timeout_storage.cs
@@ -11,25 +11,25 @@
 
     public class When_dispatched_timeout_already_removed_from_timeout_storage : NServiceBusAcceptanceTest
     {
-        [Test]
-        public void Should_rollback_and_not_deliver_timeout_when_using_dtc()
-        {
-            var context = new Context();
-
-            Scenario.Define(context)
-                .WithEndpoint<TimeoutHandlingEndpoint>(b => b
-                    .CustomConfig(configure => Configure.Transactions.Advanced(s => s.EnableDistributedTransactions()))
-                    .Given(bus =>
-                    {
-                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
-                    }))
-                .Done(c => c.AttemptedToRemoveTimeout || c.MessageReceived)
-                .Run();
-
-            Assert.IsFalse(context.MessageReceived, "Message should not be delivered using dtc");
-            Assert.AreEqual(2, context.NumberOfProcessingAttempts, "The rollback should cause a retry");
-            Assert.IsTrue(context.AttemptedToRemoveTimeout);
-        }
+//        [Test]
+//        public void Should_rollback_and_not_deliver_timeout_when_using_dtc()
+//        {
+//            var context = new Context();
+//
+//            Scenario.Define(context)
+//                .WithEndpoint<TimeoutHandlingEndpoint>(b => b
+//                    .CustomConfig(configure => Configure.Transactions.Advanced(s => s.EnableDistributedTransactions()))
+//                    .Given(bus =>
+//                    {
+//                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+//                    }))
+//                .Done(c => c.AttemptedToRemoveTimeout || c.MessageReceived)
+//                .Run();
+//
+//            Assert.IsFalse(context.MessageReceived, "Message should not be delivered using dtc");
+//            Assert.AreEqual(2, context.NumberOfProcessingAttempts, "The rollback should cause a retry");
+//            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+//        }
 
 //        [CoreConcern]
 //        [Test]
@@ -52,25 +52,25 @@
 //            Assert.IsTrue(context.AttemptedToRemoveTimeout);
 //        }
 
-        [Test]
-        public void Should_deliver_timeout_anyway_when_using_no_tx()
-        {
-            var context = new Context();
-
-            Scenario.Define(context)
-                .WithEndpoint<TimeoutHandlingEndpoint>(b => b
-                    .CustomConfig(configure => Configure.Transactions.Disable())
-                    .Given(bus =>
-                    {
-                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
-                    }))
-                .Done(c => c.AttemptedToRemoveTimeout && c.MessageReceived)
-                .Run();
-
-            Assert.IsTrue(context.MessageReceived, "Message should be delivered although timeout processing fails");
-            Assert.AreEqual(1, context.NumberOfProcessingAttempts, "Should not retry without transactions enabled");
-            Assert.IsTrue(context.AttemptedToRemoveTimeout);
-        }
+//        [Test]
+//        public void Should_deliver_timeout_anyway_when_using_no_tx()
+//        {
+//            var context = new Context();
+//
+//            Scenario.Define(context)
+//                .WithEndpoint<TimeoutHandlingEndpoint>(b => b
+//                    .CustomConfig(configure => Configure.Transactions.Disable())
+//                    .Given(bus =>
+//                    {
+//                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+//                    }))
+//                .Done(c => c.AttemptedToRemoveTimeout && c.MessageReceived)
+//                .Run();
+//
+//            Assert.IsTrue(context.MessageReceived, "Message should be delivered although timeout processing fails");
+//            Assert.AreEqual(1, context.NumberOfProcessingAttempts, "Should not retry without transactions enabled");
+//            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+//        }
 
         public class Context : ScenarioContext
         {

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_dispatched_timeout_already_removed_from_timeout_storage.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_dispatched_timeout_already_removed_from_timeout_storage.cs
@@ -1,0 +1,183 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Transactions;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NServiceBus.Timeout.Core;
+    using NUnit.Framework;
+
+    public class When_dispatched_timeout_already_removed_from_timeout_storage : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_rollback_and_not_deliver_timeout_when_using_dtc()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<TimeoutHandlingEndpoint>(b => b
+                    .CustomConfig(configure => Configure.Transactions.Advanced(s => s.EnableDistributedTransactions()))
+                    .Given(bus =>
+                    {
+                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+                    }))
+                .Done(c => c.AttemptedToRemoveTimeout || c.MessageReceived)
+                .Run();
+
+            Assert.IsFalse(context.MessageReceived, "Message should not be delivered using dtc");
+            Assert.AreEqual(2, context.NumberOfProcessingAttempts, "The rollback should cause a retry");
+            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+        }
+
+//        [CoreConcern]
+//        [Test]
+//        public void Should_rollback_and_deliver_timeout_anyway_when_using_native_tx()
+//        {
+//            var context = new Context();
+//
+//            Scenario.Define(context)
+//                .WithEndpoint<TimeoutHandlingEndpoint>(b => b
+//                    .CustomConfig(configure => Configure.Transactions.Advanced(s => s.DisableDistributedTransactions()))
+//                    .Given(bus =>
+//                    {
+//                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+//                    }))
+//                .Done(c => c.AttemptedToRemoveTimeout && c.MessageReceived)
+//                .Run();
+//
+//            Assert.IsTrue(context.MessageReceived, "Message should be delivered although transaction has been aborted");
+//            Assert.AreEqual(2, context.NumberOfProcessingAttempts, "The rollback should cause a retry");
+//            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+//        }
+
+        [Test]
+        public void Should_deliver_timeout_anyway_when_using_no_tx()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<TimeoutHandlingEndpoint>(b => b
+                    .CustomConfig(configure => Configure.Transactions.Disable())
+                    .Given(bus =>
+                    {
+                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+                    }))
+                .Done(c => c.AttemptedToRemoveTimeout && c.MessageReceived)
+                .Run();
+
+            Assert.IsTrue(context.MessageReceived, "Message should be delivered although timeout processing fails");
+            Assert.AreEqual(1, context.NumberOfProcessingAttempts, "Should not retry without transactions enabled");
+            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+
+            public bool AttemptedToRemoveTimeout { get; set; }
+
+            public int NumberOfProcessingAttempts { get; set; }
+        }
+
+        public class TimeoutHandlingEndpoint : EndpointConfigurationBuilder
+        {
+            public TimeoutHandlingEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class DelayedMessageHandler : IHandleMessages<MyMessage>
+            {
+                Context context;
+
+                public DelayedMessageHandler(Context context)
+                {
+                    this.context = context;
+                }
+
+                public void Handle(MyMessage message)
+                {
+                    context.MessageReceived = true;
+                }
+            }
+
+            public class EndpointConfiguration : IWantToRunWhenConfigurationIsComplete
+            {
+                Context context;
+                IPersistTimeouts originalPersister;
+
+                public EndpointConfiguration(Context context, IPersistTimeouts originalPersister)
+                {
+                    this.context = context;
+                    this.originalPersister = originalPersister;
+                }
+
+                public void Run()
+                {
+                    Configure.Component(b => new TimeoutPersistenceWrapper(originalPersister, originalPersister as IPersistTimeoutsV2, context), DependencyLifecycle.SingleInstance);
+                }
+            }
+
+            class TimeoutPersistenceWrapper : IPersistTimeouts, IPersistTimeoutsV2
+            {
+                IPersistTimeouts originalTimeoutPersister;
+                IPersistTimeoutsV2 originalTimeoutPersisterV2;
+                Context context;
+
+                public TimeoutPersistenceWrapper(IPersistTimeouts originalTimeoutPersister, IPersistTimeoutsV2 originalTimeoutPersisterV2, Context context)
+                {
+                    this.originalTimeoutPersister = originalTimeoutPersister;
+                    this.originalTimeoutPersisterV2 = originalTimeoutPersisterV2;
+                    this.context = context;
+                }
+
+                public List<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+                {
+                    return originalTimeoutPersister.GetNextChunk(startSlice, out nextTimeToRunQuery);
+                }
+
+                public void Add(TimeoutData timeout)
+                {
+                    originalTimeoutPersister.Add(timeout);
+                }
+
+                public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+                {
+                    return originalTimeoutPersister.TryRemove(timeoutId, out timeoutData);
+                }
+
+                public void RemoveTimeoutBy(Guid sagaId)
+                {
+                    originalTimeoutPersister.RemoveTimeoutBy(sagaId);
+                }
+
+                public TimeoutData Peek(string timeoutId)
+                {
+                    context.NumberOfProcessingAttempts++;
+                    return originalTimeoutPersisterV2.Peek(timeoutId);
+                }
+
+                public bool TryRemove(string timeoutId)
+                {
+                    context.AttemptedToRemoveTimeout = true;
+
+                    using (var tx = new TransactionScope(TransactionScopeOption.Suppress))
+                    {
+                        // delete the timeout so it won't be available on retries
+                        originalTimeoutPersisterV2.TryRemove(timeoutId);
+                        tx.Complete();
+                    }
+
+                    return false;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_dispatching_deferred_message_fails_without_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_dispatching_deferred_message_fails_without_dtc.cs
@@ -1,0 +1,113 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_dispatching_deferred_message_fails_without_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_be_received()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<TimeoutHandlingEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.Defer(TimeSpan.FromSeconds(3), new MyMessage());
+                    }))
+                    .Done(c => c.MessageReceived)
+                    .Run();
+
+            Assert.IsTrue(context.SendingMessageFailedOnce);
+            Assert.IsTrue(context.MessageReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+
+            public bool SendingMessageFailedOnce { get; set; }
+        }
+
+        public class TimeoutHandlingEndpoint : EndpointConfigurationBuilder
+        {
+            public TimeoutHandlingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                }).AllowExceptions();
+            }
+
+            public class DelayedMessageHandler : IHandleMessages<MyMessage>
+            {
+                Context context;
+
+                public DelayedMessageHandler(Context context)
+                {
+                    this.context = context;
+                }
+
+                public void Handle(MyMessage message)
+                {
+                    context.MessageReceived = true;
+                }
+            }
+
+            public class EndpointConfiguration : IWantToRunWhenConfigurationIsComplete
+            {
+                Context context;
+                ISendMessages originalMessageSender;
+
+                public EndpointConfiguration(Context context, ISendMessages originalMessageSender)
+                {
+                    this.context = context;
+                    this.originalMessageSender = originalMessageSender;
+                }
+
+                public void Run()
+                {
+                    Configure.Component(b => new SenderWrapper(originalMessageSender, context), DependencyLifecycle.SingleInstance);
+                }
+            }
+
+            class SenderWrapper : ISendMessages
+            {
+                ISendMessages wrappedSender;
+                Context context;
+
+                public SenderWrapper(ISendMessages wrappedSender, Context context)
+                {
+                    this.wrappedSender = wrappedSender;
+                    this.context = context;
+                }
+
+                public void Send(TransportMessage message, Address address)
+                {
+                    string realtedTimeoutId;
+                    if (message.Headers.TryGetValue("NServiceBus.RelatedToTimeoutId", out realtedTimeoutId))
+                    {
+                        // dispatched message by timeout behavior
+                        // fail first attempt:
+                        if (!context.SendingMessageFailedOnce)
+                        {
+                            context.SendingMessageFailedOnce = true;
+                            throw new Exception("simulated exception");
+                        }
+                    }
+
+                    wrappedSender.Send(message, address);
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_no_timeout_persistence.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_no_timeout_persistence.cs
@@ -1,0 +1,96 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using AcceptanceTesting.Support;
+    using Config.ConfigurationSource;
+    using Hosting.Helpers;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_no_timeout_persistence : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<MinimalServer>(config =>
+                {
+                    config.DisableTimeoutManager();
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class MinimalServer : IEndpointSetupTemplate
+        {
+            public Configure GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource)
+            {
+                var settings = runDescriptor.Settings;
+
+                SetLoggingLibrary.Log4Net(null, new ContextAppender(runDescriptor.ScenarioContext, endpointConfiguration));
+
+
+                var types = GetTypesToUse(endpointConfiguration);
+
+                var config = Configure.With(types)
+                    .CustomConfigurationSource(configSource)
+                    .DefineBuilder(settings.GetOrNull("Builder"))
+                    .DefineSerializer(settings.GetOrNull("Serializer"))
+                    .DefineTransport(settings);
+
+                return config.UnicastBus();
+            }
+
+            static IEnumerable<Type> GetTypesToUse(EndpointConfiguration endpointConfiguration)
+            {
+                var assemblies = new AssemblyScanner().GetScannableAssemblies();
+
+                var types = assemblies.Assemblies
+                                      //exclude all test types by default
+                                      .Where(a => a != Assembly.GetExecutingAssembly())
+                                      .SelectMany(a => a.GetTypes());
+
+
+                types = types.Union(GetNestedTypeRecursive(endpointConfiguration.BuilderType.DeclaringType, endpointConfiguration.BuilderType));
+
+                types = types.Union(endpointConfiguration.TypesToInclude);
+
+                return types.Where(t => !endpointConfiguration.TypesToExclude.Contains(t)).ToList();
+            }
+
+            static IEnumerable<Type> GetNestedTypeRecursive(Type rootType, Type builderType)
+            {
+                yield return rootType;
+
+                if (typeof(IEndpointConfigurationFactory).IsAssignableFrom(rootType) && rootType != builderType)
+                    yield break;
+
+                foreach (var nestedType in rootType.GetNestedTypes(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic).SelectMany(t => GetNestedTypeRecursive(t, builderType)))
+                {
+                    yield return nestedType;
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_sql_transport_with_disabled_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_sql_transport_with_disabled_dtc.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Settings;
+    using NServiceBus.Timeout.Core;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_sql_transport_with_disabled_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_warning()
+        {
+            var context = new Context();
+
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                    .WithEndpoint<Endpoint>()
+                    .Done(c => c.EndpointsStarted)
+                    .Run())
+                    .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            StringAssert.Contains("You are using an outdated transport which can lead to message loss!", scenarioException.InnerException.Message);
+        }
+
+        [Test]
+        public void Endpoint_should_start_when_warning_suppressed()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(c => c
+                    .CustomConfig(configure => configure.SuppressOutdatedTransportWarning()))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Configurer.ConfigureComponent<UpdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                    config.UseTransport<OutdatedSqlServerTransport>();
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class OutdatedSqlServerTransport : TransportDefinition
+        {
+            // needs to contain SqlServer in the name
+            public OutdatedSqlServerTransport()
+            {
+                HasSupportForDistributedTransactions = true;
+            }
+        }
+
+        public class OutdatedSqlServerTransportConfiguration : IConfigureTransport<OutdatedSqlServerTransport>
+        {
+            public void Configure(Configure config)
+            {
+                var selectedTransportDefinition = new OutdatedSqlServerTransport();
+                SettingsHolder.Set("NServiceBus.Transport.SelectedTransport", selectedTransportDefinition);
+                config.Configurer.RegisterSingleton<TransportDefinition>(selectedTransportDefinition);
+            }
+        }
+    }
+
+    
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_sql_transport_with_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_sql_transport_with_dtc.cs
@@ -1,0 +1,59 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Settings;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_sql_transport_with_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Configurer.ConfigureComponent<UpdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                    config.UseTransport<OutdatedSqlServerTransport>();
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class OutdatedSqlServerTransport : TransportDefinition
+        {
+            // needs to contain SqlServer in the name
+            public OutdatedSqlServerTransport()
+            {
+                HasSupportForDistributedTransactions = true;
+            }
+        }
+
+        public class OutdatedSqlServerTransportConfiguration : IConfigureTransport<OutdatedSqlServerTransport>
+        {
+            public void Configure(Configure config)
+            {
+                var selectedTransportDefinition = new OutdatedSqlServerTransport();
+                SettingsHolder.Set("NServiceBus.Transport.SelectedTransport", selectedTransportDefinition);
+                config.Configurer.RegisterSingleton<TransportDefinition>(selectedTransportDefinition);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs
@@ -1,0 +1,57 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Timeout.Core;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_warning()
+        {
+            var context = new Context();
+
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run())
+                .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            StringAssert.Contains("You are using an outdated timeout persistence which can lead to message loss!", scenarioException.InnerException.Message);
+        }
+
+        [Test]
+        public void Endpoint_should_start_when_warning_suppressed()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(c => c
+                    .CustomConfig(config => config.SuppressOutdatedTimeoutPersistenceWarning()))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Configurer.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        } 
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs
@@ -1,0 +1,39 @@
+﻿//namespace NServiceBus.AcceptanceTests.Timeouts
+//{
+//    using NServiceBus.AcceptanceTesting;
+//    using NServiceBus.AcceptanceTests.EndpointTemplates;
+//    using NUnit.Framework;
+//
+//    [CoreConcern]
+//    public class When_endpoint_uses_outdated_timeout_persistence_with_dtc : NServiceBusAcceptanceTest
+//    {
+//        [Test]
+//        public void Endpoint_should_start()
+//        {
+//            var context = new Context();
+//
+//            Scenario.Define(context)
+//                .WithEndpoint<Endpoint>()
+//                .Done(c => c.EndpointsStarted)
+//                .Run();
+//
+//            Assert.IsTrue(context.EndpointsStarted);
+//        }
+//
+//        public class Endpoint : EndpointConfigurationBuilder
+//        {
+//            public Endpoint()
+//            {
+//                EndpointSetup<DefaultServer>(config =>
+//                {
+//                    config.Configurer.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+//                    Configure.Transactions.Advanced(s => s.EnableDistributedTransactions());
+//                });
+//            }
+//        }
+//
+//        public class Context : ScenarioContext
+//        {
+//        } 
+//    }
+//}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Settings;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_timeout_persistence_without_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_warning()
+        {
+            var context = new Context();
+
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                    .WithEndpoint<Endpoint>()
+                    .Done(c => c.EndpointsStarted)
+                    .Run())
+                    .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            StringAssert.Contains("You are using an outdated timeout persistence which can lead to message loss!", scenarioException.InnerException.Message);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.UseTransport<NonDtcTransportDefinition>();
+                    config.Configurer.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        class NonDtcTransportDefinition : TransportDefinition
+        {
+            public NonDtcTransportDefinition()
+            {
+                HasSupportForDistributedTransactions = false;
+            }
+        }
+
+        class NonDtcTransport : IConfigureTransport<NonDtcTransportDefinition>
+        {
+            public void Configure(Configure config)
+            {
+                var selectedTransportDefinition = Activator.CreateInstance<NonDtcTransportDefinition>();
+                SettingsHolder.Set("NServiceBus.Transport.SelectedTransport", selectedTransportDefinition);
+                config.Configurer.RegisterSingleton<TransportDefinition>(selectedTransportDefinition);
+            }
+        } 
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_updated_sql_transport_with_disabled_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_updated_sql_transport_with_disabled_dtc.cs
@@ -1,0 +1,61 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Settings;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_updated_sql_transport_with_disabled_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Configurer.ConfigureComponent<UpdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                    config.UseTransport<UpdatedSqlServerTransport>();
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class UpdatedSqlServerTransport : TransportDefinition
+        {
+            // needs to contain SqlServer in the name
+            public UpdatedSqlServerTransport()
+            {
+                HasSupportForDistributedTransactions = true;
+                SettingsHolder.Set("NServiceBus.Transport.SupportsNativeTransactionSuppression", true);
+            }
+        }
+
+        public class UpdatedSqlServerTransportConfiguration : IConfigureTransport<UpdatedSqlServerTransport>
+        {
+            public void Configure(Configure config)
+            {
+                var selectedTransportDefinition = new UpdatedSqlServerTransport();
+                SettingsHolder.Set("NServiceBus.Transport.SelectedTransport", selectedTransportDefinition);
+                config.Configurer.RegisterSingleton<TransportDefinition>(selectedTransportDefinition);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_updated_timeout_persistence.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_updated_timeout_persistence.cs
@@ -1,0 +1,38 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_updated_timeout_persistence : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Configurer.ConfigureComponent<UpdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }  
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/FakePromotableResourceManager.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/FakePromotableResourceManager.cs
@@ -1,0 +1,54 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+
+    public class FakePromotableResourceManager : IPromotableSinglePhaseNotification, IEnlistmentNotification
+    {
+        public static Guid ResourceManagerId = Guid.Parse("6f057e24-a0d8-4c95-b091-b8dc9a916fa4");
+
+        public void Prepare(PreparingEnlistment preparingEnlistment)
+        {
+            preparingEnlistment.Prepared();
+        }
+
+        public void Commit(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+
+        public void Rollback(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+
+        public void InDoubt(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+
+
+        public void Initialize()
+        {
+        }
+
+        public void SinglePhaseCommit(SinglePhaseEnlistment singlePhaseEnlistment)
+        {
+            singlePhaseEnlistment.Committed();
+        }
+
+        public void Rollback(SinglePhaseEnlistment singlePhaseEnlistment)
+        {
+            singlePhaseEnlistment.Done();
+        }
+
+        public byte[] Promote()
+        {
+            return TransactionInterop.GetTransmitterPropagationToken(new CommittableTransaction());
+
+        }
+
+
+    }
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_dtc_disabled.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_dtc_disabled.cs
@@ -1,0 +1,66 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_with_dtc_disabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_escalate_a_single_durable_rm_to_dtc_tx()
+        {
+
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonDTCEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.HandlerInvoked)
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c =>
+                        {
+                            //this check mainly applies to MSMQ who creates a DTC tx right of the bat if DTC is on
+                            Assert.AreEqual(Guid.Empty, c.DistributedIdentifierBefore, "No DTC tx should exist before enlistment");
+                            Assert.True(c.CanEnlistPromotable, "A promotable RM should be able to enlist");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerInvoked { get; set; }
+
+            public Guid DistributedIdentifierBefore { get; set; }
+
+            public bool CanEnlistPromotable { get; set; }
+        }
+
+        public class NonDTCEndpoint : EndpointConfigurationBuilder
+        {
+            public NonDTCEndpoint()
+            {
+                Configure.Transactions.Advanced(a => a.DisableDistributedTransactions());
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessage messageThatIsEnlisted)
+                {
+                    Context.DistributedIdentifierBefore = Transaction.Current.TransactionInformation.DistributedIdentifier;
+
+                    Context.CanEnlistPromotable = Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager());
+
+                    Context.HandlerInvoked = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_dtc_enabled.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_dtc_enabled.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_with_dtc_enabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_enlist_the_receive_in_the_dtc_tx()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<DTCEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.HandlerInvoked)
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c => Assert.False(c.CanEnlistPromotable, "There should exists a DTC tx"))
+                    .Run();
+        }
+
+        [Test]
+        public void Basic_assumptions_promotable_should_fail_if_durable_already_exists()
+        {
+            using (var tx = new TransactionScope())
+            {
+                Transaction.Current.EnlistDurable(FakePromotableResourceManager.ResourceManagerId, new FakePromotableResourceManager(), EnlistmentOptions.None);
+                Assert.False(Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager()));
+
+                tx.Complete();
+            }
+        }
+
+
+        [Test]
+        public void Basic_assumptions_second_promotable_should_fail()
+        {
+            using (var tx = new TransactionScope())
+            {
+                Assert.True(Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager()));
+
+                Assert.False(Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager()));
+
+                tx.Complete();
+            }
+        }
+
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerInvoked { get; set; }
+
+            public bool CanEnlistPromotable { get; set; }
+        }
+
+        public class DTCEndpoint : EndpointConfigurationBuilder
+        {
+            public DTCEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessage messageThatIsEnlisted)
+                {
+                    Context.CanEnlistPromotable = Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager());
+                    Context.HandlerInvoked = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_the_default_settings.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_the_default_settings.cs
@@ -1,0 +1,53 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_with_the_default_settings : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_wrap_the_handler_pipeline_with_a_transactionscope()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<TransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.HandlerInvoked)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.AmbientTransactionExists, "There should exist an ambient transaction"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool AmbientTransactionExists { get; set; }
+            public bool HandlerInvoked { get; set; }
+        }
+
+        public class TransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public TransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessage messageThatIsEnlisted)
+                {
+                    Context.AmbientTransactionExists = (Transaction.Current != null);
+                    Context.HandlerInvoked = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_transactions_disabled.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_transactions_disabled.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_with_transactions_disabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_roll_the_message_back_to_the_queue_in_case_of_failure()
+        {
+
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.TestComplete)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.AreEqual(1, c.TimesCalled, "Should not retry the message"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool TestComplete { get; set; }
+
+            public int TimesCalled { get; set; }
+        }
+
+        public class NonTransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public NonTransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Transactions.Disable())
+                    .AllowExceptions();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+                public void Handle(MyMessage message)
+                {
+                    Context.TimesCalled++;
+
+                    using (new TransactionScope(TransactionScopeOption.Suppress))
+                    {
+                        Bus.SendLocal(new CompleteTest());
+                    }
+
+                    throw new Exception("Simulated exception");
+                }
+            }
+
+            public class CompleteTestHandler : IHandleMessages<CompleteTest>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(CompleteTest message)
+                {
+                    Context.TestComplete = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+        [Serializable]
+        public class CompleteTest : ICommand
+        {
+        }
+
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_sending_a_message_from_a_non_transactional_endpoint_with_a_ambient_transaction_enabled.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_sending_a_message_from_a_non_transactional_endpoint_with_a_ambient_transaction_enabled.cs
@@ -1,0 +1,91 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_sending_a_message_from_a_non_transactional_endpoint_with_a_ambient_transaction_enabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_roll_the_message_back_to_the_queue_in_case_of_failure()
+        {
+
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.TestComplete)
+                    .Repeat(r => r.For<AllDtcTransports>()) 
+                    .Should(c => Assert.False(c.MessageEnlistedInTheAmbientTxReceived, "The enlisted bus.Send should not commit"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool TestComplete { get; set; }
+
+            public bool MessageEnlistedInTheAmbientTxReceived { get; set; }
+        }
+
+        public class NonTransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public NonTransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        Configure.Transactions.Disable();
+                        Configure.Transactions.Advanced(t => t.WrapHandlersExecutionInATransactionScope());
+                    })
+                    .AllowExceptions();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+                public void Handle(MyMessage message)
+                {
+                    Bus.SendLocal(new CompleteTest
+                        {
+                            EnlistedInTheAmbientTx = true
+                        });
+
+                    using (new TransactionScope(TransactionScopeOption.Suppress))
+                    {
+                        Bus.SendLocal(new CompleteTest());
+                    }
+
+                    throw new Exception("Simulated exception");
+                }
+            }
+
+            public class CompleteTestHandler : IHandleMessages<CompleteTest>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(CompleteTest message)
+                {
+                    if (!Context.MessageEnlistedInTheAmbientTxReceived)
+                        Context.MessageEnlistedInTheAmbientTxReceived = message.EnlistedInTheAmbientTx;
+
+                    Context.TestComplete = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+        [Serializable]
+        public class CompleteTest : ICommand
+        {
+            public bool EnlistedInTheAmbientTx { get; set; }
+        }
+
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_sending_messages_within_an_ambient_transaction.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_sending_messages_within_an_ambient_transaction.cs
@@ -1,0 +1,122 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_sending_messages_within_an_ambient_transaction : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_deliver_them_until_the_commit_phase()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<TransactionalEndpoint>(b => b.Given((bus, context) =>
+                        {
+                            using (var tx = new TransactionScope())
+                            {
+                                bus.Send(new MessageThatIsEnlisted { SequenceNumber = 1 });
+                                bus.Send(new MessageThatIsEnlisted { SequenceNumber = 2 });
+
+                                //send another message as well so that we can check the order in the receiver
+                                using (new TransactionScope(TransactionScopeOption.Suppress))
+                                {
+                                    bus.Send(new MessageThatIsNotEnlisted());
+                                }
+
+                                tx.Complete();
+                            }
+                        }))
+                    .Done(c => c.MessageThatIsNotEnlistedHandlerWasCalled && c.TimesCalled >= 2)
+                    .Repeat(r => r.For(Transports.Default)) //not stable for sqlserver
+                    .Should(c => Assert.AreEqual(1, c.SequenceNumberOfFirstMessage,"The transport should preserve the order in which the transactional messages are delivered to the queuing system"))
+                    .Run();
+        }
+
+        [Test]
+        public void Should_not_deliver_them_on_rollback()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<TransactionalEndpoint>(b => b.Given(bus =>
+                        {
+                            using (new TransactionScope())
+                            {
+                                bus.Send(new MessageThatIsEnlisted());
+
+                                //rollback
+                            }
+
+                            bus.Send(new MessageThatIsNotEnlisted());
+
+                        }))
+                    .Done(c => c.MessageThatIsNotEnlistedHandlerWasCalled)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.False(c.MessageThatIsEnlistedHandlerWasCalled, "The transactional handler should not be called"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageThatIsEnlistedHandlerWasCalled { get; set; }
+
+            public bool MessageThatIsNotEnlistedHandlerWasCalled { get; set; }
+            public int TimesCalled { get; set; }
+
+            public int SequenceNumberOfFirstMessage { get; set; }
+
+            public bool NonTransactionalHandlerCalledFirst { get; set; }
+        }
+
+        public class TransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public TransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MessageThatIsEnlisted>(typeof(TransactionalEndpoint))
+                    .AddMapping<MessageThatIsNotEnlisted>(typeof(TransactionalEndpoint));
+            }
+
+            public class MessageThatIsEnlistedHandler : IHandleMessages<MessageThatIsEnlisted>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageThatIsEnlisted messageThatIsEnlisted)
+                {
+                    Context.MessageThatIsEnlistedHandlerWasCalled = true;
+                    Context.TimesCalled++;
+
+                    if (Context.SequenceNumberOfFirstMessage == 0)
+                    {
+                        Context.SequenceNumberOfFirstMessage = messageThatIsEnlisted.SequenceNumber;
+                    }
+                }
+            }
+
+            public class MessageThatIsNotEnlistedHandler : IHandleMessages<MessageThatIsNotEnlisted>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageThatIsNotEnlisted messageThatIsNotEnlisted)
+                {
+                    Context.MessageThatIsNotEnlistedHandlerWasCalled = true;
+                    Context.NonTransactionalHandlerCalledFirst = !Context.MessageThatIsEnlistedHandlerWasCalled;
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class MessageThatIsEnlisted : ICommand
+        {
+            public int SequenceNumber { get; set; }
+        }
+        [Serializable]
+        public class MessageThatIsNotEnlisted : ICommand
+        {
+        }
+
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
@@ -1,0 +1,124 @@
+﻿namespace NServiceBus.AcceptanceTests.Versioning
+{
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using PubSub;
+    using ScenarioDescriptors;
+
+    public class When_multiple_versions_of_a_message_is_published : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_deliver_is_to_both_v1_and_vX_subscribers()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<V2Publisher>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                            {
+                                if (s.SubscriberReturnAddress.Queue.Contains("V1Subscriber"))
+                                    context.V1Subscribed = true;
+
+                                if (s.SubscriberReturnAddress.Queue.Contains("V2Subscriber"))
+                                    context.V2Subscribed = true;
+                            })
+                            )
+                             .When(c => c.V1Subscribed && c.V2Subscribed, (bus, c) => bus.Publish<V2Event>(e =>
+                                 {
+                                     e.SomeData = 1;
+                                     e.MoreInfo = "dasd";
+                                 })))
+                    .WithEndpoint<V1Subscriber>(b => b.Given((bus,c) =>
+                        {
+                            bus.Subscribe<V1Event>();
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                c.V1Subscribed = true;
+                        }))
+                    .WithEndpoint<V2Subscriber>(b => b.Given((bus,c) =>
+                        {
+                            bus.Subscribe<V2Event>();
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                c.V2Subscribed = true;
+                        }))
+                    .Done(c => c.V1SubscriberGotTheMessage && c.V2SubscriberGotTheMessage)
+                    .Repeat(r =>//broken for active mq until #1098 is fixed
+                                    r.For<AllSerializers>(Serializers.Binary)) //versioning isn't supported for binary serialization
+                    .Should(c =>
+                        {
+                            //put asserts in here if needed
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool V1SubscriberGotTheMessage { get; set; }
+
+            public bool V2SubscriberGotTheMessage { get; set; }
+
+            public bool V1Subscribed { get; set; }
+
+            public bool V2Subscribed { get; set; }
+        }
+
+        public class V2Publisher : EndpointConfigurationBuilder
+        {
+            public V2Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+
+            }
+        }
+        public class V1Subscriber : EndpointConfigurationBuilder
+        {
+            public V1Subscriber()
+            {
+                EndpointSetup<DefaultServer>()
+                    .ExcludeType<V2Event>()
+                    .AddMapping<V1Event>(typeof(V2Publisher));
+
+            }
+
+
+            class V1Handler:IHandleMessages<V1Event>
+            {
+                public Context Context { get; set; }
+                public void Handle(V1Event message)
+                {
+                    Context.V1SubscriberGotTheMessage = true;
+                }
+            }
+        }
+
+
+        public class V2Subscriber : EndpointConfigurationBuilder
+        {
+            public V2Subscriber()
+            {
+                EndpointSetup<DefaultServer>()
+                     .AddMapping<V2Event>(typeof(V2Publisher));
+            }
+
+            class V2Handler : IHandleMessages<V2Event>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V2Event message)
+                {
+                    Context.V2SubscriberGotTheMessage = true;
+                }
+            }
+        }
+
+
+        public interface V1Event : IEvent
+        {
+            int SomeData { get; set; }
+        }
+
+        public interface V2Event : V1Event
+        {
+            string MoreInfo { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/NServiceBus.Azure.WindowsAzureServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/NServiceBus.Azure.WindowsAzureServiceBus.AcceptanceTests.csproj
@@ -81,8 +81,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="ripple.dependencies.config" />
+    <None Include="ripple.dependencies.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/Properties/AssemblyInfo.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/Properties/AssemblyInfo.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+//[assembly: AssemblyVersion("1.0.0.0")]
+//[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/ripple.dependencies.config
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests/ripple.dependencies.config
@@ -3,4 +3,3 @@ NUnit
 NServiceBus
 NServiceBus.Interfaces
 NServiceBus.AcceptanceTesting
-NServiceBus.AcceptanceTests.Sources

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus/AzureServiceBusDequeueStrategy.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus/AzureServiceBusDequeueStrategy.cs
@@ -150,8 +150,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
                         {
                             tryProcessMessage(transportMessage);
                         }
-
-                        brokeredMessage.SafeComplete(); 
                     }
                 }
                 catch (Exception ex)

--- a/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus/Utils/BrokeredMessageConverter.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureServiceBus/Utils/BrokeredMessageConverter.cs
@@ -31,6 +31,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
             }
             else
             {
+                // ReSharper disable once UseObjectOrCollectionInitializer
                 t = new TransportMessage();
                 t.Body = rawMessage;
             }

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
@@ -1,0 +1,130 @@
+﻿namespace NServiceBus.AcceptanceTests.Audit
+{
+    using System;
+    using System.Linq;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+
+    public class When_a_message_is_audited : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_preserve_the_original_body()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                    .WithEndpoint<AuditSpyEndpoint>()
+                    .Done(c => c.AuditChecksum != default(byte))
+                    .Run();
+
+            Assert.AreEqual(context.OriginalBodyChecksum, context.AuditChecksum, "The body of the message sent to audit should be the same as the original message coming off the queue");
+        }
+
+        [Test]
+        public void Should_add_the_license_diagnostic_headers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                    .WithEndpoint<AuditSpyEndpoint>()
+                    .Done(c => c.HasDiagnosticLicensingHeaders)
+                    .Run();
+            Assert.IsTrue(context.HasDiagnosticLicensingHeaders);
+        }
+
+
+        public class Context : ScenarioContext
+        {
+            public byte OriginalBodyChecksum { get; set; }
+            public byte AuditChecksum { get; set; }
+            public bool HasDiagnosticLicensingHeaders { get; set; }
+        }
+
+        public class EndpointWithAuditOn : EndpointConfigurationBuilder
+        {
+            public EndpointWithAuditOn()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<AuditSpyEndpoint>();
+            }
+
+            class BodyMutator : IMutateIncomingTransportMessages, INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+
+                    var originalBody = transportMessage.Body;
+
+                    Context.OriginalBodyChecksum = Checksum(originalBody);
+
+                    // modifying the body by adding a line break
+                    var modifiedBody = new byte[originalBody.Length + 1];
+
+                    Buffer.BlockCopy(originalBody, 0, modifiedBody, 0, originalBody.Length);
+
+                    modifiedBody[modifiedBody.Length - 1] = 13;
+
+                    transportMessage.Body = modifiedBody;
+                }
+
+                public void Init()
+                {
+                    Configure.Component<BodyMutator>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited> { public void Handle(MessageToBeAudited message) { } }
+        }
+
+        class AuditSpyEndpoint : EndpointConfigurationBuilder
+        {
+            public AuditSpyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class BodySpy : IMutateIncomingTransportMessages, INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    Context.AuditChecksum = Checksum(transportMessage.Body);
+                    string licenseExpired;
+                    Context.HasDiagnosticLicensingHeaders = transportMessage.Headers.TryGetValue(Headers.HasLicenseExpired, out licenseExpired);
+                }
+
+                public void Init()
+                {
+                    Configure.Component<BodySpy>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited> { public void Handle(MessageToBeAudited message) { } }
+        }
+
+        public static byte Checksum(byte[] data)
+        {
+            var longSum = data.Sum(x => (long)x);
+            return unchecked((byte)longSum);
+        }
+
+        [Serializable]
+        public class MessageToBeAudited : IMessage
+        {
+        }
+
+        
+    }
+
+#pragma warning restore  612, 618
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Audit/When_using_auditing_as_a_feature.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Audit/When_using_auditing_as_a_feature.cs
@@ -1,0 +1,111 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Audit
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_using_auditing_as_a_feature : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_not_be_forwarded_to_auditQueue_when_auditing_is_disabled()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+            .WithEndpoint<EndpointWithAuditOff>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+            .WithEndpoint<EndpointThatHandlesAuditMessages>()
+            .Done(c => c.IsMessageHandlingComplete)
+            .Run();
+
+            Assert.IsFalse(context.IsMessageHandledByTheAuditEndpoint);
+        }
+
+        [Test]
+        public void Message_should_be_forwarded_to_auditQueue_when_auditing_is_enabled()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+            .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+            .WithEndpoint<EndpointThatHandlesAuditMessages>()
+            .Done(c => c.IsMessageHandlingComplete)
+            .Run();
+
+            Assert.IsTrue(context.IsMessageHandledByTheAuditEndpoint);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsMessageHandlingComplete { get; set; }
+            public bool IsMessageHandledByTheAuditEndpoint { get; set; }
+        }
+
+        public class EndpointWithAuditOff : EndpointConfigurationBuilder
+        {
+           
+            public EndpointWithAuditOff()
+            {
+                // Although the AuditTo seems strange here, this test tries to fake the scenario where
+                // even though the user has specified audit config, because auditing is explicitly turned
+                // off, no messages should be audited.
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<Features.Audit>())
+                    .AuditTo<EndpointThatHandlesAuditMessages>();
+
+            }
+
+            class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+                }
+            }
+        }
+
+        public class EndpointWithAuditOn : EndpointConfigurationBuilder
+        {
+
+            public EndpointWithAuditOn()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<EndpointThatHandlesAuditMessages>();
+            }
+
+            class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+                }
+            }
+        }
+
+        public class EndpointThatHandlesAuditMessages : EndpointConfigurationBuilder
+        {
+
+            public EndpointThatHandlesAuditMessages()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandledByTheAuditEndpoint = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeAudited : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_Deferring_a_message.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_Deferring_a_message.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_Deferring_a_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_be_received()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.Defer(TimeSpan.FromSeconds(3), new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.IsTrue(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_aborting_the_behavior_chain.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_aborting_the_behavior_chain.cs
@@ -1,0 +1,73 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_aborting_the_behavior_chain : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Subsequent_handlers_will_not_be_invoked()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.Send(Address.Local, new SomeMessage())))
+                .Done(c => c.FirstHandlerInvoked)
+                .Run();
+
+            Assert.That(context.FirstHandlerInvoked, Is.True);
+            Assert.That(context.SecondHandlerInvoked, Is.False);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool FirstHandlerInvoked { get; set; }
+            public bool SecondHandlerInvoked { get; set; }
+        }
+
+        [Serializable]
+        public class SomeMessage : IMessage { }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class EnsureOrdering : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.Specify(First<FirstHandler>.Then<SecondHandler>());
+                }
+            }
+
+            class FirstHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                
+                public IBus Bus { get; set; }
+                
+                public void Handle(SomeMessage message)
+                {
+                    Context.FirstHandlerInvoked = true;
+
+                    Bus.DoNotContinueDispatchingCurrentMessageToHandlers();
+                }
+            }
+
+            class SecondHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                
+                public void Handle(SomeMessage message)
+                {
+                    Context.SecondHandlerInvoked = true;
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_handling_current_message_later.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_handling_current_message_later.cs
@@ -1,0 +1,157 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using System.Linq;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_handling_current_message_later : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_commit_unit_of_work()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.Send(Address.Local, new SomeMessage())))
+                .Done(c => c.Done)
+                .Run();
+
+            Assert.That(context.AnotherMessageReceivedCount, Is.EqualTo(2), 
+                "First handler sends a message to self, which should result in AnotherMessage being dispatched twice");
+        }
+
+        [Test, Description("NOTE the double negation - we should probably modify this behavior somehow")]
+        public void Should_not_not_execute_subsequent_handlers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.Send(Address.Local, new SomeMessage())))
+                .Done(c => c.Done)
+                .Run();
+
+            Assert.That(context.ThirdHandlerInvocationCount, Is.EqualTo(2), 
+                "Since calling HandleCurrentMessageLater does not discontinue message dispatch, the third handler should be called twice as well");
+        }
+
+        [Test]
+        public void Handlers_are_executed_in_the_right_order()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.Send(Address.Local, new SomeMessage())))
+                .Done(c => c.Done)
+                .Run();
+
+            var events = context.Events;
+            CollectionAssert
+                .AreEquivalent(new[]
+                               {
+                                   "FirstHandler:Executed",
+                                   "SecondHandler:Sending message to the back of the queue",
+                                   "ThirdHandler:Executed",
+                                   "FirstHandler:Executed",
+                                   "SecondHandler:Handling the message this time",
+                                   "ThirdHandler:Executed"
+                               },
+                    events);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string[] Events { get; set; }
+            
+            public bool SomeMessageHasBeenRequeued { get; set; }
+
+            public bool Done
+            {
+                get { return ThirdHandlerInvocationCount >= 2 && AnotherMessageReceivedCount == 2; }
+            }
+
+            public int AnotherMessageReceivedCount { get; set; }
+            
+            public int ThirdHandlerInvocationCount { get; set; }
+        }
+
+        [Serializable]
+        public class SomeMessage : IMessage { }
+
+        [Serializable]
+        public class AnotherMessage : IMessage { }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class EnsureOrdering : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.Specify(First<FirstHandler>.Then<SecondHandler>().AndThen<ThirdHandler>());
+                }
+            }
+
+            class FirstHandler : IHandleMessages<SomeMessage>, IHandleMessages<AnotherMessage>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+
+                public void Handle(SomeMessage message)
+                {
+                    Context.RegisterEvent("FirstHandler:Executed");
+                    Bus.SendLocal(new AnotherMessage());
+                }
+
+                public void Handle(AnotherMessage message)
+                {
+                    Context.AnotherMessageReceivedCount++;
+                }
+            }
+
+            class SecondHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+                public void Handle(SomeMessage message)
+                {
+                    if (!Context.SomeMessageHasBeenRequeued)
+                    {
+                        Context.RegisterEvent("SecondHandler:Sending message to the back of the queue");
+                        Bus.HandleCurrentMessageLater();
+                        Context.SomeMessageHasBeenRequeued = true;
+                    }
+                    else
+                    {
+                        Context.RegisterEvent("SecondHandler:Handling the message this time");
+                    }
+                }
+            }
+
+            class ThirdHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                public void Handle(SomeMessage message)
+                {
+                    Context.RegisterEvent("ThirdHandler:Executed");
+                    Context.ThirdHandlerInvocationCount++;
+                }
+            }
+        }
+    }
+
+    static class ContextEx
+    {
+        public static void RegisterEvent(this When_handling_current_message_later.Context context, string description)
+        {
+            context.Events = context.Events
+                .Concat(new[] {description})
+                .ToArray();
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_registering_a_callback_for_a_local_message.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_registering_a_callback_for_a_local_message.cs
@@ -1,0 +1,64 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_registering_a_callback_for_a_local_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_trigger_the_callback_when_the_response_comes_back()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointWithLocalCallback>(b=>b.Given(
+                        (bus,context)=>bus.SendLocal(new MyRequest()).Register(r =>
+                        {
+                            Assert.True(context.HandlerGotTheRequest);
+                            context.CallbackFired = true;
+                        })))
+                    .Done(c => c.CallbackFired)
+                    .Repeat(r =>r.For(Transports.Default))
+                    .Should(c =>
+                    {
+                        Assert.True(c.CallbackFired);
+                        Assert.True(c.HandlerGotTheRequest);
+                    })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerGotTheRequest { get; set; }
+
+            public bool CallbackFired { get; set; }
+        }
+
+        public class EndpointWithLocalCallback : EndpointConfigurationBuilder
+        {
+            public EndpointWithLocalCallback()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Assert.False(Context.CallbackFired);
+                    Context.HandlerGotTheRequest = true;
+
+                    Bus.Return(1);
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage{}
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_that_is_registered_multiple_times_to_another_endpoint.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_that_is_registered_multiple_times_to_another_endpoint.cs
@@ -1,0 +1,100 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using System.Threading;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_sending_a_message_that_is_registered_multiple_times_to_another_endpoint : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void First_registration_should_be_the_final_destination()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MyCommand1())))
+                    .WithEndpoint<Receiver1>()
+                    .WithEndpoint<Receiver2>()
+                    .Done(c => c.WasCalled1 || c.WasCalled2)
+                    .Run();
+
+            Assert.IsTrue(context.WasCalled1);
+            Assert.IsFalse(context.WasCalled2);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled1 { get; set; }
+            public bool WasCalled2 { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MyCommand1>(typeof(Receiver1))
+                    .AddMapping<MyCommand2>(typeof(Receiver2));
+            }
+        }
+
+        public class Receiver1 : EndpointConfigurationBuilder
+        {
+            public Receiver1()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyBaseCommand>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyBaseCommand message)
+                {
+                    Context.WasCalled1 = true;
+                    Thread.Sleep(2000); // Just to be sure the other receiver is finished
+                }
+            }
+        }
+
+        public class Receiver2 : EndpointConfigurationBuilder
+        {
+            public Receiver2()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyBaseCommand>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyBaseCommand message)
+                {
+                    Context.WasCalled2 = true;
+                    Thread.Sleep(2000); // Just to be sure the other receiver is finished
+                }
+            }
+        }
+
+        [Serializable]
+        public abstract class MyBaseCommand : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MyCommand1 : MyBaseCommand
+        {
+        }
+
+        [Serializable]
+        public class MyCommand2 : MyBaseCommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_to_another_endpoint.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_to_another_endpoint.cs
@@ -1,0 +1,99 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using System.Collections.Generic;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_sending_a_message_to_another_endpoint : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_the_message()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<Sender>(b => b.Given((bus, context) =>
+                    {
+                        bus.OutgoingHeaders["MyStaticHeader"] = "StaticHeaderValue";
+                        bus.Send<MyMessage>(m=>
+                        {
+                            m.Id = context.Id;
+                            m.SetHeader("MyHeader","MyHeaderValue");
+                        });
+                    }))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.WasCalled)
+                    .Repeat(r =>r.For(Serializers.Binary)
+                                  .For<AllBuilders>()
+                    )
+                    .Should(c =>
+                        {
+                            Assert.True(c.WasCalled, "The message handler should be called");
+                            Assert.AreEqual(1, c.TimesCalled, "The message handler should only be invoked once");
+                            Assert.True(c.ReceivedHeaders[Headers.OriginatingEndpoint].Contains("Sender"), "The sender should attach its endpoint name as a header");
+                            Assert.True(c.ReceivedHeaders[Headers.ProcessingEndpoint].Contains("Receiver"), "The receiver should attach its endpoint name as a header");
+                            Assert.AreEqual("StaticHeaderValue",c.ReceivedHeaders["MyStaticHeader"], "Static headers should be attached to outgoing messages");
+                            Assert.AreEqual("MyHeaderValue", c.MyHeader, "Static headers should be attached to outgoing messages");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+
+            public int TimesCalled { get; set; }
+
+            public IDictionary<string, string> ReceivedHeaders { get; set; }
+
+            public Guid Id { get; set; }
+
+            public string MyHeader { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MyMessage>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+
+            public IBus Bus { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                if (Context.Id != message.Id)
+                    return;
+
+                Context.TimesCalled++;
+
+                Context.MyHeader = message.GetHeader("MyHeader");
+
+                Context.ReceivedHeaders = Bus.CurrentMessageContext.Headers;
+
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_with_no_correlation_id.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_sending_a_message_with_no_correlation_id.cs
@@ -1,0 +1,73 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_sending_a_message_with_no_correlation_id : NServiceBusAcceptanceTest
+    {  
+        [Test]
+        public void Should_use_the_message_id_as_the_correlation_id()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<CorrelationEndpoint>(b => b.Given(bus => bus.Send(Address.Local, new MyRequest())))
+                    .Done(c => c.GotRequest)
+                    .Run();
+
+            Assert.AreEqual(context.MessageIdReceived, context.CorrelationIdReceived, "Correlation id should match MessageId");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string MessageIdReceived { get; set; }
+            public bool GotRequest { get; set; }
+            public string CorrelationIdReceived { get; set; }
+        }
+
+        public class CorrelationEndpoint : EndpointConfigurationBuilder
+        {
+            public CorrelationEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class GetValueOfIncomingCorrelationId:IMutateIncomingTransportMessages,INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    Context.CorrelationIdReceived = transportMessage.CorrelationId;
+                    Context.MessageIdReceived = transportMessage.Id;
+                }
+
+                public void Init()
+                {
+                    Configure.Component<GetValueOfIncomingCorrelationId>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest response)
+                {
+                    Context.GotRequest = true;
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_starting_a_send_only.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_starting_a_send_only.cs
@@ -1,0 +1,22 @@
+﻿﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+ {
+     using System;
+     using NUnit.Framework;
+
+     public class When_starting_a_send_only : NServiceBusAcceptanceTest
+     {
+         [Test]
+         public void Should_not_need_audit_or_fault_forwarding_config_to_start()
+         {
+             using ((IDisposable)Configure.With(new Type[]
+                                  {
+                                  })
+                 .DefaultBuilder()
+                 .UnicastBus()
+                 .SendOnly())
+             {
+             }
+
+         }
+     }
+ }

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_custom_correlation_id.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_custom_correlation_id.cs
@@ -1,0 +1,74 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_using_a_custom_correlation_id : NServiceBusAcceptanceTest
+    {
+        static string CorrelationId = "my_custom_correlation_id";
+       
+        [Test]
+        public void Should_use_the_given_id_as_the_transport_level_correlation_id()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<CorrelationEndpoint>(b => b.Given(bus => bus.Send(Address.Local, CorrelationId, new MyRequest())))
+                    .Done(c => c.GotRequest)
+                    .Run();
+
+            Assert.AreEqual(CorrelationId, context.CorrelationIdReceived, "Correlation ids should match");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotRequest { get; set; }
+
+            public string CorrelationIdReceived { get; set; }
+        }
+
+        public class CorrelationEndpoint : EndpointConfigurationBuilder
+        {
+            public CorrelationEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class GetValueOfIncomingCorrelationId:IMutateIncomingTransportMessages,INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    Context.CorrelationIdReceived = transportMessage.CorrelationId;
+                }
+
+                public void Init()
+                {
+                    Configure.Component<GetValueOfIncomingCorrelationId>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest response)
+                {
+                    Context.GotRequest = true;
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_greedy_convention.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_greedy_convention.cs
@@ -1,0 +1,64 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_a_greedy_convention : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_the_message()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<EndPoint>(b => b.Given((bus, context) => bus.SendLocal(new MyMessage
+                    {Id = context.Id})))
+                    .Done(c => c.WasCalled)
+                    .Repeat(r =>r
+                        .For(Transports.Msmq)
+                    )
+                    .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+
+            public Guid Id { get; set; }
+        }
+
+        public class EndPoint : EndpointConfigurationBuilder
+        {
+            public EndPoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.DefiningMessagesAs(MessageConvention));
+            }
+
+            static bool MessageConvention(Type t)
+            {
+                return t.Namespace != null && 
+                    (t.Namespace.EndsWith(".Messages") ||  (t == typeof(MyMessage)));
+            }
+        }
+
+        [Serializable]
+        public class MyMessage
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+            public void Handle(MyMessage message)
+            {
+                if (Context.Id != message.Id)
+                    return;
+
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_message_with_TimeToBeReceived_has_expired.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_message_with_TimeToBeReceived_has_expired.cs
@@ -1,0 +1,49 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_using_a_message_with_TimeToBeReceived_has_expired : NServiceBusAcceptanceTest
+    {
+        [Test, Ignore("The TTL will only be started at the moment the timeoutmanager sends the message back, still giving the test a second to receive it")]
+        public void Message_should_not_be_received()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.Defer(TimeSpan.FromSeconds(5), new MyMessage())))
+                    .Run(TimeSpan.FromSeconds(10));
+            Assert.IsFalse(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        [TimeToBeReceived("00:00:01")]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_message_with_TimeToBeReceived_has_not_expired.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_message_with_TimeToBeReceived_has_not_expired.cs
@@ -1,0 +1,53 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_using_a_message_with_TimeToBeReceived_has_not_expired : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_be_received()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.IsTrue(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        [TimeToBeReceived("00:00:10")]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_callbacks_in_a_scaleout_scenario.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_callbacks_in_a_scaleout_scenario.cs
@@ -1,0 +1,125 @@
+﻿namespace NServiceBus.AcceptanceTests.BasicMessaging
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+    using Support;
+
+    public class When_using_callbacks_in_a_scaleout_scenario : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Each_client_should_have_a_unique_input_queue_to_avoid_processing_each_others_callbacks()
+        {
+            Scenario.Define(() => new Context{Id = Guid.NewGuid()})
+                    .WithEndpoint<Client>(b => b.CustomConfig(c=>RuntimeEnvironment.MachineNameAction = () => "ClientA")
+                        .Given((bus, context) => bus.Send(new MyRequest { Id = context.Id, Client = RuntimeEnvironment.MachineName })
+                                                        .Register(r => context.CallbackAFired = true)))
+                    .WithEndpoint<Client>(b => b.CustomConfig(c=>RuntimeEnvironment.MachineNameAction = () => "ClientB")
+                        .Given((bus, context) => bus.Send(new MyRequest { Id = context.Id, Client = RuntimeEnvironment.MachineName })
+                         .Register(r => context.CallbackBFired = true)))
+                    .WithEndpoint<Server>()
+                    .Done(c => c.ClientAGotResponse && c.ClientBGotResponse)
+                    .Repeat(r =>r.For<AllBrokerTransports>()
+                    )
+                    .Should(c =>
+                        {
+                            Assert.True(c.CallbackAFired, "Callback on ClientA should fire");
+                            Assert.True(c.CallbackBFired, "Callback on ClientB should fire");
+                            Assert.False(c.ResponseEndedUpAtTheWrongClient, "One of the responses ended up at the wrong client");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public bool ClientAGotResponse { get; set; }
+
+            public bool ClientBGotResponse { get; set; }
+
+            public bool ResponseEndedUpAtTheWrongClient { get; set; }
+
+            public bool CallbackAFired { get; set; }
+
+            public bool CallbackBFired { get; set; }
+        }
+
+        public class Client : EndpointConfigurationBuilder
+        {
+            public Client()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.ScaleOut(s => s.UseUniqueBrokerQueuePerMachine()))
+                    .AddMapping<MyRequest>(typeof(Server));
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyResponse response)
+                {
+                    if (Context.Id != response.Id)
+                        return;
+
+                    if (RuntimeEnvironment.MachineName == "ClientA")
+                        Context.ClientAGotResponse = true;
+                    else
+                    {
+                        Context.ClientBGotResponse = true;
+                    }
+
+                    if (RuntimeEnvironment.MachineName != response.Client)
+                        Context.ResponseEndedUpAtTheWrongClient = true;
+                }
+            }
+        }
+
+        public class Server : EndpointConfigurationBuilder
+        {
+            public Server()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    if (Context.Id != request.Id)
+                        return;
+
+
+                    Bus.Reply(new MyResponse { Id = request.Id,Client = request.Client });
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+            public Guid Id { get; set; }
+
+            public string Client { get; set; }
+        }
+
+        [Serializable]
+        public class MyResponse : IMessage
+        {
+            public Guid Id { get; set; }
+
+            public string Client { get; set; }
+        }
+
+
+    
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BusStartStop/When_bus_start_and_stops_with_a_pending_message.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BusStartStop/When_bus_start_and_stops_with_a_pending_message.cs
@@ -1,0 +1,58 @@
+﻿namespace NServiceBus.AcceptanceTests.BusStartStop
+{
+    using System;
+    using System.Threading;
+    using AcceptanceTesting.Support;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_bus_start_and_stops_with_a_pending_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_throw()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => SendMessages(b))
+                    .Run(TimeSpan.FromMilliseconds(100));
+
+            Thread.Sleep(100);
+        }
+
+
+        EndpointBehaviorBuilder<Context> SendMessages(EndpointBehaviorBuilder<Context> b)
+        {
+            return b.Given((bus, context) => bus.SendLocal(new Message()));
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class MessageHandler : IHandleMessages<Message>
+            {
+                public void Handle(Message message)
+                {
+                    Thread.Sleep(100);
+                }
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BusStartStop/When_bus_start_raises_an_inmemory_message.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/BusStartStop/When_bus_start_raises_an_inmemory_message.cs
@@ -1,0 +1,69 @@
+﻿namespace NServiceBus.AcceptanceTests.BusStartStop
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+#pragma warning disable 612, 618
+    public class When_bus_start_raises_an_inmemory_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_throw()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.GotMessage)
+                .Repeat(r => r.For<AllBuilders>())
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotMessage;
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class MessageHandler : IHandleMessages<Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(Message message)
+                {
+                    Context.GotMessage = true;
+                }
+            }
+        }
+
+        public class Foo : IWantToRunWhenBusStartsAndStops
+        {
+            public IBus Bus { get; set; }
+
+            public void Start()
+            {
+                Bus.InMemory.Raise(new Message());
+            }
+
+            public void Stop()
+            {
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+
+    }
+#pragma warning restore  612, 618
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Configuration/When_a_config_override_is_found.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Configuration/When_a_config_override_is_found.cs
@@ -1,0 +1,65 @@
+﻿namespace NServiceBus.AcceptanceTests.Configuration
+{
+    using Config;
+    using Config.ConfigurationSource;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Faults.Forwarder;
+    using NUnit.Framework;
+    using Unicast;
+    using Unicast.Transport;
+
+    public class When_a_config_override_is_found : NServiceBusAcceptanceTest
+    {
+        static Address CustomErrorQ = Address.Parse("MyErrorQ");
+
+        [Test]
+        public void Should_be_used_instead_of_pulling_the_settings_from_appconfig()
+        {
+            var context = Scenario.Define<Context>()
+                    .WithEndpoint<ConfigOverrideEndpoint>(b => b.When(c => c.EndpointsStarted, (bus, cc) =>
+                        {
+                            var unicastBus = (UnicastBus)bus;
+                            var transport = (TransportReceiver)unicastBus.Transport;
+                            var fm = (FaultManager)transport.FailureManager;
+
+                            cc.ErrorQueueUsedByTheEndpoint = fm.ErrorQueue;
+                            cc.IsDone = true;
+                        }))
+                    .Done(c => c.IsDone)
+                    .Run();
+
+            Assert.AreEqual(CustomErrorQ, context.ErrorQueueUsedByTheEndpoint, "The error queue should have been changed");
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsDone { get; set; }
+
+            public Address ErrorQueueUsedByTheEndpoint { get; set; }
+        }
+
+        public class ConfigOverrideEndpoint : EndpointConfigurationBuilder
+        {
+            public ConfigOverrideEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.MessageForwardingInCaseOfFault());
+            }
+
+            public class ConfigErrorQueue : IProvideConfiguration<MessageForwardingInCaseOfFaultConfig>
+            {
+                public MessageForwardingInCaseOfFaultConfig GetConfiguration()
+                {
+
+                    return new MessageForwardingInCaseOfFaultConfig
+                    {
+                        ErrorQueue = CustomErrorQ.ToString()
+                    };
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
@@ -1,0 +1,67 @@
+﻿namespace NServiceBus.AcceptanceTests.DataBus
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_sending_databus_properties:NServiceBusAcceptanceTest
+    {
+        static byte[] PayloadToSend = new byte[1024 * 1024 * 10];
+
+        [Test]
+        public void Should_receive_the_message_the_largeproperty_correctly()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus=> bus.Send(new MyMessageWithLargePayload
+                        {
+                            Payload = new DataBusProperty<byte[]>(PayloadToSend) 
+                        })))
+                    .WithEndpoint<Receiver>()
+                    .Done(context => context.ReceivedPayload != null)
+                    .Repeat(r => r.For<AllSerializers>())
+                    .Should(c => Assert.AreEqual(PayloadToSend, c.ReceivedPayload, "The large payload should be marshalled correctly using the databus"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public byte[] ReceivedPayload { get; set; }
+        }
+
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c => c.FileShareDataBus(@".\databus\sender"))
+                    .AddMapping<MyMessageWithLargePayload>(typeof (Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c => c.FileShareDataBus(@".\databus\sender"));
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessageWithLargePayload>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessageWithLargePayload messageWithLargePayload)
+                {
+                    Context.ReceivedPayload = messageWithLargePayload.Payload.Value;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessageWithLargePayload : ICommand
+        {
+            public DataBusProperty<byte[]> Payload { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System;
+    using System.Collections.Generic;
+    using Config;
+    using Config.ConfigurationSource;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_encryption : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_decrypted_message()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageWithSecretData
+                        {
+                            Secret = "betcha can't guess my secret",
+                            SubProperty = new MySecretSubProperty {Secret = "My sub secret"},
+                            CreditCards = new List<CreditCardDetails>
+                                {
+                                    new CreditCardDetails
+                                        {
+                                            ValidTo = DateTime.UtcNow.AddYears(1),
+                                            Number = "312312312312312"
+                                        },
+                                    new CreditCardDetails
+                                        {
+                                            ValidTo = DateTime.UtcNow.AddYears(2),
+                                            Number = "543645546546456"
+                                        }
+                                }
+                        })))
+                    .Done(c => c.Done)
+                    .Repeat(r => r.For<AllSerializers>())
+                    .Should(c =>
+                        {
+                            Assert.AreEqual("betcha can't guess my secret", c.Secret);
+                            Assert.AreEqual("My sub secret", c.SubPropertySecret);
+                            CollectionAssert.AreEquivalent(new List<string> { "312312312312312", "543645546546456" }, c.CreditCards);
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+
+            public string Secret { get; set; }
+
+            public string SubPropertySecret { get; set; }
+
+            public List<string> CreditCards { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.RijndaelEncryptionService());
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+
+                    Context.SubPropertySecret = message.SubProperty.Secret.Value;
+
+                    Context.CreditCards = new List<string>
+                    {
+                        message.CreditCards[0].Number.Value, 
+                        message.CreditCards[1].Number.Value
+                    };
+
+                    Context.Done = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageWithSecretData : IMessage
+        {
+            public WireEncryptedString Secret { get; set; }
+            public MySecretSubProperty SubProperty { get; set; }
+            public List<CreditCardDetails> CreditCards { get; set; }
+        }
+
+        [Serializable]
+        public class CreditCardDetails
+        {
+            public DateTime ValidTo { get; set; }
+            public WireEncryptedString Number { get; set; }
+        }
+
+        [Serializable]
+        public class MySecretSubProperty
+        {
+            public WireEncryptedString Secret { get; set; }
+        }
+
+        public class ConfigureEncryption: IProvideConfiguration<RijndaelEncryptionServiceConfig>
+        {
+            RijndaelEncryptionServiceConfig rijndaelEncryptionServiceConfig = new RijndaelEncryptionServiceConfig { Key = "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6" };
+
+            public RijndaelEncryptionServiceConfig GetConfiguration()
+            {
+                return rijndaelEncryptionServiceConfig;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption_with_custom_service.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption_with_custom_service.cs
@@ -1,0 +1,75 @@
+﻿namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System.Linq;
+    using NServiceBus.Encryption;
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_encryption_with_custom_service : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_decrypted_message()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageWithSecretData
+                        {
+                            Secret = "betcha can't guess my secret"
+                        })))
+                    .Done(c => c.Done)
+                    .Repeat(r => r.For<AllSerializers>())
+                    .Should(c => Assert.AreEqual("betcha can't guess my secret", c.Secret))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+            public string Secret { get; set; }
+        }
+        
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Configurer.RegisterSingleton<IEncryptionService>(new MyEncryptionService()));
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+                    Context.Done = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageWithSecretData : IMessage
+        {
+            public WireEncryptedString Secret { get; set; }
+        }
+
+
+        public class MyEncryptionService : IEncryptionService
+        {
+            public EncryptedValue Encrypt(string value)
+            {
+                return new EncryptedValue
+                {
+                    EncryptedBase64Value = new string(value.Reverse().ToArray())
+                };
+            }
+
+            public string Decrypt(EncryptedValue encryptedValue)
+            {
+                return new string(encryptedValue.EncryptedBase64Value.Reverse().ToArray());
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption_with_multikey.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Encryption/When_using_encryption_with_multikey.cs
@@ -1,0 +1,110 @@
+﻿namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System;
+    using Config;
+    using Config.ConfigurationSource;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_encryption_with_multikey : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_decrypted_message()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given((bus, context) => bus.Send(new MessageWithSecretData
+                        {
+                            Secret = "betcha can't guess my secret",
+                        })))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.Done)
+                    .Repeat(r => r.For<AllSerializers>())
+                    .Should(c => Assert.AreEqual("betcha can't guess my secret", c.Secret))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+
+            public string Secret { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c => c.RijndaelEncryptionService())
+                    .AddMapping<MessageWithSecretData>(typeof(Receiver));
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+                    Context.Done = true;
+                }
+            }
+
+            public class ConfigureEncryption : IProvideConfiguration<RijndaelEncryptionServiceConfig>
+            {
+                public RijndaelEncryptionServiceConfig GetConfiguration()
+                {
+                    return new RijndaelEncryptionServiceConfig
+                    {
+                        Key = "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"
+                    };
+                }
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c => c.RijndaelEncryptionService());
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+                    Context.Done = true;
+                }
+            }
+
+            public class ConfigureEncryption : IProvideConfiguration<RijndaelEncryptionServiceConfig>
+            {
+                public RijndaelEncryptionServiceConfig GetConfiguration()
+                {
+                    return new RijndaelEncryptionServiceConfig
+                    {
+                        Key = "adDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6",
+                        ExpiredKeys = new RijndaelExpiredKeyCollection
+                        {
+                            new RijndaelExpiredKey
+                            {
+                                Key = "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"
+                            }
+                        }
+                    };
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageWithSecretData : IMessage
+        {
+            public WireEncryptedString Secret { get; set; }
+        }
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -1,0 +1,187 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Collections.Generic;
+    using ObjectBuilder.Common;
+    using ObjectBuilder.Common.Config;
+    using Persistence.InMemory.SagaPersister;
+    using Persistence.InMemory.SubscriptionStorage;
+    using Persistence.InMemory.TimeoutPersister;
+    using Persistence.Msmq.SubscriptionStorage;
+    using Persistence.Raven.SagaPersister;
+    using Persistence.Raven.SubscriptionStorage;
+    using Persistence.Raven.TimeoutPersister;
+    using ScenarioDescriptors;
+    using Serializers.Binary;
+    using Serializers.Json;
+    using Serializers.XML;
+
+    public static class ConfigureExtensions
+    {
+        public static string GetOrNull(this IDictionary<string, string> dictionary, string key)
+        {
+            if (!dictionary.ContainsKey(key))
+            {
+                return null;
+            }
+
+            return dictionary[key];
+        }
+
+        public static Configure DefineTransport(this Configure config, IDictionary<string, string> settings)
+        {
+            if (!settings.ContainsKey("Transport"))
+            {
+                settings = Transports.Default.Settings;
+            }
+
+            var transportType = Type.GetType(settings["Transport"]);
+
+            return config.UseTransport(transportType, () => settings["Transport.ConnectionString"]);
+        }
+
+        public static Configure DefineSerializer(this Configure config, string serializer)
+        {
+            if (string.IsNullOrEmpty(serializer))
+            {
+                return config; //xml is the default
+            }
+
+            var type = Type.GetType(serializer);
+
+            if (type == typeof(XmlMessageSerializer))
+            {
+                Configure.Serialization.Xml();
+                return config;
+            }
+
+            if (type == typeof(JsonMessageSerializer))
+            {
+                Configure.Serialization.Json();
+                return config;
+            }
+
+            if (type == typeof(BsonMessageSerializer))
+            {
+                Configure.Serialization.Bson();
+                return config;
+            }
+
+            if (type == typeof(BinaryMessageSerializer))
+            {
+                Configure.Serialization.Binary();
+                return config;
+            }
+
+            throw new InvalidOperationException("Unknown serializer:" + serializer);
+        }
+
+        public static Configure DefineTimeoutPersister(this Configure config, string persister)
+        {
+            if (string.IsNullOrEmpty(persister))
+            {
+                persister = TimeoutPersisters.Default.Settings["TimeoutPersister"];
+            }
+
+            if (persister.Contains(typeof(InMemoryTimeoutPersistence).FullName))
+            {
+                return config.UseInMemoryTimeoutPersister();
+            }
+
+            if (persister.Contains(typeof(RavenTimeoutPersistence).FullName))
+            {
+                config.RavenPersistence(() => "url=http://localhost:8080");
+                return config.UseRavenTimeoutPersister();
+            }
+
+            CallConfigureForPersister(config, persister);
+
+            return config;
+        }
+
+        public static Configure DefineSagaPersister(this Configure config, string persister)
+        {
+            if (string.IsNullOrEmpty(persister))
+            {
+                persister = SagaPersisters.Default.Settings["SagaPersister"];
+            }
+
+            if (persister.Contains(typeof(InMemorySagaPersister).FullName))
+            {
+                return config.InMemorySagaPersister();
+            }
+
+            if (persister.Contains(typeof(RavenSagaPersister).FullName))
+            {
+                config.RavenPersistence(() => "url=http://localhost:8080");
+                return config.RavenSagaPersister();
+            }
+
+            CallConfigureForPersister(config, persister);
+
+            return config;
+        }
+
+        public static Configure DefineSubscriptionStorage(this Configure config, string persister)
+        {
+            if (string.IsNullOrEmpty(persister))
+            {
+                persister = SubscriptionPersisters.Default.Settings["SubscriptionStorage"];
+            }
+
+            if (persister.Contains(typeof(InMemorySubscriptionStorage).FullName))
+            {
+                return config.InMemorySubscriptionStorage();
+            }
+
+            if (persister.Contains(typeof(RavenSubscriptionStorage).FullName))
+            {
+                config.RavenPersistence(() => "url=http://localhost:8080");
+                return config.RavenSubscriptionStorage();
+            }
+
+            if (persister.Contains(typeof(MsmqSubscriptionStorage).FullName))
+            {
+                return config.MsmqSubscriptionStorage();
+            }
+
+            CallConfigureForPersister(config, persister);
+
+            return config;
+        }
+
+        static void CallConfigureForPersister(Configure config, string persister)
+        {
+            var type = Type.GetType(persister);
+
+            var typeName = "Configure" + type.Name;
+
+            var configurerType = Type.GetType(typeName, false);
+
+            if (configurerType == null)
+            {
+                return;
+            }
+
+            var configurer = Activator.CreateInstance(configurerType);
+
+            dynamic dc = configurer;
+
+            dc.Configure(config);
+        }
+
+        public static Configure DefineBuilder(this Configure config, string builder)
+        {
+            if (string.IsNullOrEmpty(builder))
+            {
+                return config.DefaultBuilder();
+            }
+
+            var container = (IContainer) Activator.CreateInstance(Type.GetType(builder));
+
+            ConfigureCommon.With(config, container);
+
+            return config;
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ContextAppender.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ContextAppender.cs
@@ -1,0 +1,35 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using AcceptanceTesting;
+    using AcceptanceTesting.Support;
+    using log4net.Appender;
+    using log4net.Core;
+
+    public class ContextAppender : AppenderSkeleton
+    {
+        public ContextAppender(ScenarioContext context, EndpointConfiguration endpointConfiguration)
+        {
+            this.context = context;
+            this.endpointConfiguration = endpointConfiguration;
+        }
+
+        protected override void Append(LoggingEvent loggingEvent)
+        {
+            if (!endpointConfiguration.AllowExceptions && loggingEvent.ExceptionObject != null)
+            {
+                lock (context)
+                {
+                    context.Exceptions += loggingEvent.ExceptionObject + "/n/r";
+                }
+            }
+            if (loggingEvent.Level >= Level.Warn)
+            {
+                context.RecordLog(endpointConfiguration.EndpointName, loggingEvent.Level.ToString(), loggingEvent.RenderedMessage);
+            }
+
+        }
+
+        ScenarioContext context;
+        readonly EndpointConfiguration endpointConfiguration;
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -1,0 +1,84 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using AcceptanceTesting.Support;
+    using Config.ConfigurationSource;
+    using Hosting.Helpers;
+    using NServiceBus;
+    using Settings;
+
+    public class DefaultServer : IEndpointSetupTemplate
+    {
+        public Configure GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource)
+        {
+            var settings = runDescriptor.Settings;
+
+            SetLoggingLibrary.Log4Net(null, new ContextAppender(runDescriptor.ScenarioContext, endpointConfiguration));
+
+            var types = GetTypesToUse(endpointConfiguration);
+
+            var transportToUse = settings.GetOrNull("Transport");
+
+            Configure.Features.Enable<Features.Sagas>();
+
+            SettingsHolder.SetDefault("ScaleOut.UseSingleBrokerQueue", true);
+
+            var config = Configure.With(types)
+                            .DefineEndpointName(endpointConfiguration.EndpointName)
+                            .CustomConfigurationSource(configSource)
+                            .DefineBuilder(settings.GetOrNull("Builder"))
+                            .DefineSerializer(settings.GetOrNull("Serializer"))
+                            .DefineTransport(settings)
+                            .DefineSagaPersister(settings.GetOrNull("SagaPersister"));
+
+            if (transportToUse == null ||
+                transportToUse.Contains("Msmq") ||
+                transportToUse.Contains("SqlServer") ||
+                transportToUse.Contains("RabbitMq"))
+            {
+                config.DefineTimeoutPersister(settings.GetOrNull("TimeoutPersister"));
+            }
+
+            if (transportToUse == null || transportToUse.Contains("Msmq") || transportToUse.Contains("SqlServer"))
+            {
+                config.DefineSubscriptionStorage(settings.GetOrNull("SubscriptionStorage"));
+            }
+
+            return config.UnicastBus();
+        }
+
+        static IEnumerable<Type> GetTypesToUse(EndpointConfiguration endpointConfiguration)
+        {
+            var assemblies = new AssemblyScanner().GetScannableAssemblies();
+
+            var types = assemblies.Assemblies
+                //exclude all test types by default
+                                  .Where(a => a != Assembly.GetExecutingAssembly())
+                                  .SelectMany(a => a.GetTypes());
+
+
+            types = types.Union(GetNestedTypeRecursive(endpointConfiguration.BuilderType.DeclaringType, endpointConfiguration.BuilderType));
+
+            types = types.Union(endpointConfiguration.TypesToInclude);
+
+            return types.Where(t => !endpointConfiguration.TypesToExclude.Contains(t)).ToList();
+        }
+
+        static IEnumerable<Type> GetNestedTypeRecursive(Type rootType, Type builderType)
+        {
+            yield return rootType;
+
+            if (typeof(IEndpointConfigurationFactory).IsAssignableFrom(rootType) && rootType != builderType)
+                yield break;
+
+            foreach (var nestedType in rootType.GetNestedTypes(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic).SelectMany(t => GetNestedTypeRecursive(t, builderType)))
+            {
+                yield return nestedType;
+            }
+        }
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/SerializerCorrupter.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/SerializerCorrupter.cs
@@ -1,0 +1,17 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Reflection;
+
+    static class SerializerCorrupter
+    {
+
+        public static void Corrupt()
+        {
+            var msmqUtilitiesType = Type.GetType("NServiceBus.Transports.Msmq.MsmqUtilities, NServiceBus.Core");
+            var headerSerializerField = msmqUtilitiesType.GetField("headerSerializer", BindingFlags.Static | BindingFlags.NonPublic);
+            headerSerializerField.SetValue(null, null);
+        }
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage.cs
@@ -1,0 +1,56 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_cant_convert_to_TransportMessage : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_send_message_to_error_queue()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus => bus.Send(new Message())))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.GetAllLogs().Any(l => l.Level == "error"))
+                    .Repeat(r => r.For(ScenarioDescriptors.Transports.Msmq))
+                    .Should(c =>
+                    {
+                        var logs = c.GetAllLogs();
+                        Assert.True(logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
+                    })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<Message>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                SerializerCorrupter.Corrupt();
+                EndpointSetup<DefaultServer>()
+                    .AllowExceptions();
+            }
+
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_NoTransactions.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_NoTransactions.cs
@@ -1,0 +1,58 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using IMessage = NServiceBus.IMessage;
+
+    public class When_cant_convert_to_TransportMessage_NoTransactions : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_send_message_to_error_queue()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus => bus.Send(new Message())))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.GetAllLogs().Any(l => l.Level == "error"))
+                    .Repeat(r => r.For(ScenarioDescriptors.Transports.Msmq))
+                    .Should(c =>
+                    {
+                        var logs = c.GetAllLogs();
+                        Assert.True(logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
+                    })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                Configure.Transactions.Disable();
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<Message>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                SerializerCorrupter.Corrupt();
+                Configure.Transactions.Disable();
+                EndpointSetup<DefaultServer>()
+                    .AllowExceptions();
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_SuppressedDTC.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_SuppressedDTC.cs
@@ -1,0 +1,57 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_cant_convert_to_TransportMessage_SuppressedDTC : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_send_message_to_error_queue()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus => bus.Send(new Message())))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.GetAllLogs().Any(l => l.Level == "error"))
+                    .Repeat(r => r.For(ScenarioDescriptors.Transports.Msmq))
+                    .Should(c =>
+                    {
+                        var logs = c.GetAllLogs();
+                        Assert.True(logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
+                    })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                Configure.Transactions.Advanced(settings => settings.DisableDistributedTransactions());
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<Message>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                SerializerCorrupter.Corrupt();
+                Configure.Transactions.Advanced(settings => settings.DisableDistributedTransactions());
+                EndpointSetup<DefaultServer>()
+                    .AllowExceptions();
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_response_between_sites.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_response_between_sites.cs
@@ -1,0 +1,105 @@
+﻿namespace NServiceBus.AcceptanceTests.Gateway
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_doing_request_response_between_sites : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Callback_should_be_fired()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<SiteA>(
+                    b => b.Given((bus, c) =>
+                        bus.SendToSites(new[] { "SiteB" }, new MyRequest())
+                            .Register(result => c.GotCallback = true)))
+                .WithEndpoint<SiteB>()
+                .Done(c => c.GotCallback)
+                .Run(TimeSpan.FromSeconds(2000));
+
+            Assert.IsTrue(context.GotCallback);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotCallback { get; set; }
+        }
+
+        public class SiteA : EndpointConfigurationBuilder
+        {
+            public SiteA()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway()
+                    .UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Sites = new SiteCollection
+                        {
+                            new SiteConfig
+                            {
+                                Key = "SiteB",
+                                Address = "http://localhost:25799/SiteB/",
+                                ChannelType = "http"
+                            }
+                        };
+
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25799/SiteA/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+            }
+        }
+
+        public class SiteB : EndpointConfigurationBuilder
+        {
+            public SiteB()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway().UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25799/SiteB/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public IBus Bus { get; set; }
+                public void Handle(MyRequest request)
+                {
+                    Bus.Reply(new MyResponse());
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : ICommand
+        {
+        }
+        [Serializable]
+        public class MyResponse : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_response_with_databus_between_sites.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_response_with_databus_between_sites.cs
@@ -1,0 +1,143 @@
+﻿namespace NServiceBus.AcceptanceTests.Gateway
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_doing_request_response_with_databus_between_sites : NServiceBusAcceptanceTest
+    {
+        static readonly byte[] PayloadToSend = new byte[1024 * 1024 * 10];
+
+        [Test]
+        public void Should_be_able_to_reply_to_the_message_using_databus()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<SiteA>(
+                    b => b.Given((bus, context) =>
+                        bus.SendToSites(new[] { "SiteB" }, new MyRequest { Payload = new DataBusProperty<byte[]>(PayloadToSend) })
+                            .Register(result => context.GotCallback = true)))
+                .WithEndpoint<SiteB>()
+                .Done(c => c.GotResponseBack && c.GotCallback)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c =>
+                {
+                    Assert.AreEqual(PayloadToSend, c.SiteBReceivedPayload,
+                        "The large payload should be marshalled correctly using the databus");
+                    Assert.AreEqual(PayloadToSend, c.SiteAReceivedPayloadInResponse,
+                        "The large payload should be marshalled correctly using the databus");
+                    Assert.AreEqual(@"http,http://localhost:25899/SiteA/", c.OriginatingSiteForRequest);
+                    Assert.AreEqual(@"http,http://localhost:25899/SiteB/", c.OriginatingSiteForResponse);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotResponseBack { get; set; }
+            public bool GotCallback { get; set; }
+            public byte[] SiteBReceivedPayload { get; set; }
+            public byte[] SiteAReceivedPayloadInResponse { get; set; }
+            public string OriginatingSiteForRequest { get; set; }
+            public string OriginatingSiteForResponse { get; set; }
+        }
+
+        public class SiteA : EndpointConfigurationBuilder
+        {
+            public SiteA()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway()
+                    .UseInMemoryGatewayPersister()
+                    .FileShareDataBus(@".\databus\siteA"))
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Sites = new SiteCollection
+                        {
+                            new SiteConfig
+                            {
+                                Key = "SiteB",
+                                Address = "http://localhost:25899/SiteB/",
+                                ChannelType = "http"
+                            }
+                        };
+
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25899/SiteA/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+
+                public void Handle(MyResponse response)
+                {
+                    Context.GotResponseBack = true;
+                    Context.SiteAReceivedPayloadInResponse = response.OriginalPayload.Value;
+                    
+                    // Inspect the headers to find the originating site address 
+                    Context.OriginatingSiteForResponse = Bus.CurrentMessageContext.Headers[Headers.OriginatingSite];
+                }
+            }
+        }
+
+        public class SiteB : EndpointConfigurationBuilder
+        {
+            public SiteB()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway().UseInMemoryGatewayPersister()
+                    .FileShareDataBus(@".\databus\siteB"))
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25899/SiteB/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public IBus Bus { get; set; }
+                public Context Context { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Context.SiteBReceivedPayload = request.Payload.Value;
+                    Bus.Reply(new MyResponse {OriginalPayload = request.Payload});
+
+                    // Inspect the headers to find the originating site address
+                    Context.OriginatingSiteForRequest = Bus.CurrentMessageContext.Headers[Headers.OriginatingSite];
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : ICommand
+        {
+            public DataBusProperty<byte[]> Payload { get; set; }
+        }
+
+        [Serializable]
+        public class MyResponse : IMessage
+        {
+            public DataBusProperty<byte[]> OriginalPayload { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_return.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_doing_request_return.cs
@@ -1,0 +1,101 @@
+﻿namespace NServiceBus.AcceptanceTests.Gateway
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_doing_request_return : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Callback_should_be_fired()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<SiteA>(
+                    b => b.Given((bus, c) =>
+                        bus.SendToSites(new[] { "SiteB" }, new MyRequest())
+                            .Register(result => c.GotCallback = true)))
+                .WithEndpoint<SiteB>()
+                .Done(c => c.GotCallback)
+                .Run(TimeSpan.FromSeconds(2000));
+
+            Assert.IsTrue(context.GotCallback);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotCallback { get; set; }
+        }
+
+        public class SiteA : EndpointConfigurationBuilder
+        {
+            public SiteA()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway()
+                    .UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Sites = new SiteCollection
+                        {
+                            new SiteConfig
+                            {
+                                Key = "SiteB",
+                                Address = "http://localhost:25699/SiteB/",
+                                ChannelType = "http"
+                            }
+                        };
+
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25699/SiteA/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+            }
+        }
+
+        public class SiteB : EndpointConfigurationBuilder
+        {
+            public SiteB()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway().UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25699/SiteB/",
+                                ChannelType = "http",
+                                Default = true
+                            }
+                        };
+                    });
+
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public IBus Bus { get; set; }
+                public void Handle(MyRequest request)
+                {
+                    Bus.Return(1);
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_sending_a_message_to_another_site.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_sending_a_message_to_another_site.cs
@@ -1,0 +1,112 @@
+﻿namespace NServiceBus.AcceptanceTests.Gateway
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_sending_a_message_to_another_site : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_able_to_reply_to_the_message()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Headquarters>(b => b.Given(bus => bus.SendToSites(new[] { "SiteA" }, new MyRequest())))
+                    .WithEndpoint<SiteA>()
+                    .Done(c => c.GotResponseBack)
+                    .Repeat(r => r.For(Transports.Default)
+                    )
+                    .Should(c => Assert.IsTrue(c.GotResponseBack))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotResponseBack { get; set; }
+        }
+
+        public class Headquarters : EndpointConfigurationBuilder
+        {
+            public Headquarters()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway().UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                        {
+                            c.Sites = new SiteCollection
+                                {
+                                    new SiteConfig
+                                        {
+                                            Key = "SiteA",
+                                            Address = "http://localhost:25899/SiteA/",
+                                            ChannelType = "http"
+                                        }
+                                };
+
+                            c.Channels = new ChannelCollection
+                                {
+                                    new ChannelConfig
+                                        {
+                                             Address = "http://localhost:25899/Headquarters/",
+                                            ChannelType = "http"
+                                        }
+                                };
+
+
+                        });
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyResponse response)
+                {
+                    Context.GotResponseBack = true;
+                }
+            }
+        }
+
+        public class SiteA : EndpointConfigurationBuilder
+        {
+            public SiteA()
+            {
+                EndpointSetup<DefaultServer>(c => c.RunGateway().UseInMemoryGatewayPersister())
+                    .AllowExceptions()
+                        .WithConfig<GatewayConfig>(c =>
+                        {
+                            c.Channels = new ChannelCollection
+                                {
+                                    new ChannelConfig
+                                        {
+                                             Address = "http://localhost:25899/SiteA/",
+                                            ChannelType = "http"
+                                        }
+                                };
+                        });
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Bus.Reply(new MyResponse());
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+        }
+
+        [Serializable]
+        public class MyResponse : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_sending_a_message_via_the_gateway.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Gateway/When_sending_a_message_via_the_gateway.cs
@@ -1,0 +1,123 @@
+﻿namespace NServiceBus.AcceptanceTests.Gateway
+{
+    using System;
+    using System.IO;
+    using System.Net;
+    using System.Web;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Gateway.Utils;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+    
+    public class When_sending_a_message_via_the_gateway : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_process_message()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<Headquarters>(b => b.When(bus =>
+                {
+                    var webRequest = (HttpWebRequest)WebRequest.Create("http://localhost:25898/Headquarters/");
+                    webRequest.Method = "POST";
+                    webRequest.ContentType = "text/xml; charset=utf-8";
+                    webRequest.UserAgent = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)";
+
+                    webRequest.Headers.Add("Content-Encoding", "utf-8");
+                    webRequest.Headers.Add("NServiceBus.CallType", "Submit");
+                    webRequest.Headers.Add("NServiceBus.AutoAck", "true");
+                    webRequest.Headers.Add("MySpecialHeader", "MySpecialValue");
+                    webRequest.Headers.Add("NServiceBus.Id", Guid.NewGuid().ToString("N"));
+
+                    const string message = "<?xml version=\"1.0\" ?><Messages xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://tempuri.net/NServiceBus.AcceptanceTests.Gateway\"><MyRequest></MyRequest></Messages>";
+                    
+                    using (var messagePayload = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(message)))
+                    {
+                        webRequest.Headers.Add(HttpRequestHeader.ContentMd5, HttpUtility.UrlEncode(Hasher.Hash(messagePayload)));
+                        webRequest.ContentLength = messagePayload.Length;
+
+                        using (var requestStream = webRequest.GetRequestStream())
+                        {
+                            messagePayload.CopyTo(requestStream);
+                        }
+                    }
+
+                    while (true)
+                    {
+                        try
+                        {
+                            using (var myWebResponse = (HttpWebResponse) webRequest.GetResponse())
+                            {
+                                if (myWebResponse.StatusCode == HttpStatusCode.OK)
+                                {
+                                    break;
+                                }
+                            }
+                        }
+                        catch (WebException)
+                        {
+                        }
+                    }
+                }))
+                .Done(c => c.GotMessage)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c =>
+                {
+                    Assert.IsTrue(c.GotMessage);
+                    Assert.AreEqual("MySpecialValue", c.MySpecialHeader);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotMessage { get; set; }
+
+            public string MySpecialHeader { get; set; }
+        }
+
+        public class Headquarters : EndpointConfigurationBuilder
+        {
+            public Headquarters()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.RunGateway().UseInMemoryGatewayPersister();
+                    Configure.Serialization.Xml();
+                })
+                    .IncludeType<MyRequest>()
+                    .AllowExceptions()
+                    .WithConfig<GatewayConfig>(c =>
+                    {
+                        c.Channels = new ChannelCollection
+                        {
+                            new ChannelConfig
+                            {
+                                Address = "http://localhost:25898/Headquarters/",
+                                ChannelType = "http"
+                            }
+                        };
+                    });
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest response)
+                {
+                    Context.GotMessage = true;
+                    Context.MySpecialHeader = Bus.GetMessageHeader(response, "MySpecialHeader");
+                }
+            }
+        }
+    }
+
+    [Serializable]
+    public class MyRequest : IMessage
+    {
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/HostInformation/When_a_message_is_received.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/HostInformation/When_a_message_is_received.cs
@@ -1,0 +1,74 @@
+﻿namespace NServiceBus.AcceptanceTests.HostInformation
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Unicast;
+
+    public class When_a_message_is_received : NServiceBusAcceptanceTest
+    {
+        static Guid hostId = new Guid("39365055-daf2-439e-b84d-acbef8fd803d");
+        const string displayName = "FooBar";
+        const string displayInstanceIdentifier = "FooBar is great!";
+
+        [Test]
+        public void Host_information_should_be_available_in_headers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(e => e.Given(b => b.SendLocal(new MyMessage())))
+                .Done(c => c.HostId != Guid.Empty)
+                .Run();
+
+            Assert.AreEqual(hostId, context.HostId);
+            Assert.AreEqual(displayName, context.HostDisplayName);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid HostId { get; set; }
+            public string HostDisplayName { get; set; }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                Context.HostId = new Guid(message.GetHeader(Headers.HostId));
+                Context.HostDisplayName = message.GetHeader(Headers.HostDisplayName);
+            }
+        }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        class OverrideHostInformation : IWantToRunWhenConfigurationIsComplete
+        {
+            public UnicastBus UnicastBus { get; set; }
+
+            public void Run()
+            {
+#pragma warning disable 618
+                var hostInformation = new Hosting.HostInformation(hostId, displayName, displayInstanceIdentifier);
+#pragma warning restore 618
+
+                UnicastBus.HostInformation = hostInformation;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_calling_DoNotContinueDispatchingCurrentMessageToHandlers_from_inmemory.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_calling_DoNotContinueDispatchingCurrentMessageToHandlers_from_inmemory.cs
@@ -1,0 +1,112 @@
+﻿namespace NServiceBus.AcceptanceTests.InMemory
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+    public class When_calling_DoNotContinueDispatchingCurrentMessageToHandlers_from_inmemory : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Subsequent_inmemory_handlers_will_not_be_invoked()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.SendLocal(new SomeMessage())))
+                .Done(c => c.SecondHandlerInvoked)
+                .Run();
+
+            Assert.IsTrue(context.FirstHandlerInvoked);
+            Assert.IsTrue(context.SecondHandlerInvoked);
+            Assert.IsTrue(context.InMemoryEventReceivedByHandler1);
+            Assert.IsFalse(context.InMemoryEventReceivedByHandler2);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool FirstHandlerInvoked { get; set; }
+            public bool SecondHandlerInvoked { get; set; }
+
+            public bool InMemoryEventReceivedByHandler1 { get; set; }
+            public bool InMemoryEventReceivedByHandler2 { get; set; }
+            
+        }
+
+        [Serializable]
+        public class SomeMessage : IMessage { }
+
+        [Serializable]
+        public class InMemoryEvent : IEvent
+        {
+        }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>());
+            }
+
+            class EnsureOrdering : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.Specify(First<FirstHandler>.Then<SecondHandler>().AndThen<MyEventHandler1>().AndThen<MyEventHandler2>());
+                }
+            }
+
+            class FirstHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                
+                public IBus Bus { get; set; }
+                
+                public void Handle(SomeMessage message)
+                {
+                    Context.FirstHandlerInvoked = true;
+
+                    Bus.InMemory.Raise<InMemoryEvent>(m => { });
+
+                }
+            }
+
+            class SecondHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                
+                public void Handle(SomeMessage message)
+                {
+                    Context.SecondHandlerInvoked = true;
+                }
+            }
+
+            class MyEventHandler1 : IHandleMessages<InMemoryEvent>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+
+                public void Handle(InMemoryEvent messageThatIsEnlisted)
+                {
+                    Bus.DoNotContinueDispatchingCurrentMessageToHandlers();
+
+                    Context.InMemoryEventReceivedByHandler1 = true;
+                }
+            }
+
+            class MyEventHandler2 : IHandleMessages<InMemoryEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(InMemoryEvent messageThatIsEnlisted)
+                {
+                    Context.InMemoryEventReceivedByHandler2 = true;
+                }
+            }
+        }
+    }
+#pragma warning restore  612, 618
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.InMemory
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+    public class When_raising_an_in_memory_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_delivered_to_handlers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<InMemoryEndpoint>(b => b.Given((bus, c) => bus.SendLocal<SomeCommand>(m => { })))
+                    .Done(c => c.WasInMemoryEventReceivedByHandler1 && c.WasInMemoryEventReceivedByHandler2)
+                    .Run();
+
+            Assert.True(context.WasInMemoryEventReceivedByHandler1, "class MyEventHandler1 did not receive the in-memory event");
+            Assert.True(context.WasInMemoryEventReceivedByHandler2, "class MyEventHandler2 did not receive the in-memory event");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasInMemoryEventReceivedByHandler1 { get; set; }
+            public bool WasInMemoryEventReceivedByHandler2 { get; set; }
+
+        }
+
+        public class InMemoryEndpoint : EndpointConfigurationBuilder
+        {
+            public InMemoryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>());
+            }
+
+            public class CommandHandler : IHandleMessages<SomeCommand>
+            {
+                public IBus Bus { get; set; }
+                public void Handle(SomeCommand messageThatIsEnlisted)
+                {
+                    Bus.InMemory.Raise<MyInMemoryEvent>(m => { });
+                }
+            }
+
+            public class MyEventHandler1 : IHandleMessages<MyInMemoryEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyInMemoryEvent messageThatIsEnlisted)
+                {
+                    Context.WasInMemoryEventReceivedByHandler1 = true;
+                }
+            }
+
+            public class MyEventHandler2 : IHandleMessages<MyInMemoryEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyInMemoryEvent messageThatIsEnlisted)
+                {
+                    Context.WasInMemoryEventReceivedByHandler2 = true;
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class SomeCommand : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MyInMemoryEvent : IEvent
+        {
+        }
+    }
+#pragma warning restore  612, 618
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event_from_a_non_handler.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event_from_a_non_handler.cs
@@ -1,0 +1,78 @@
+﻿namespace NServiceBus.AcceptanceTests.InMemory
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+
+    public class When_raising_an_in_memory_event_from_a_non_handler : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_delivered_to_handlers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<InMemoryEndpoint>()
+                    .Done(c => c.WasInMemoryEventReceivedByHandler1)
+                    .Run();
+
+            Assert.True(context.WasInMemoryEventReceivedByHandler1, "class MyEventHandler1 did not receive the in-memory event");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasInMemoryEventReceivedByHandler1 { get; set; }
+      
+        }
+
+        public class InMemoryEndpoint : EndpointConfigurationBuilder
+        {
+            public InMemoryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>());
+            }
+
+            public class StartUpRunner : IWantToRunWhenBusStartsAndStops
+            {
+                public IBus Bus { get; set; }
+              
+                public void Start()
+                {
+                    Bus.InMemory.Raise<MyInMemoryEvent>(m => m.SetHeader("MyHeader","MyValue"));      
+                }
+
+                public void Stop()
+                {
+                }
+            }
+
+            public class MyEventHandler1 : IHandleMessages<MyInMemoryEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyInMemoryEvent message)
+                {
+                    Assert.AreEqual("MyValue",Headers.GetMessageHeader(message,"MyHeader"));
+                    Context.WasInMemoryEventReceivedByHandler1 = true;
+                }
+            }
+
+        }
+
+
+        [Serializable]
+        public class SomeCommand : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MyInMemoryEvent : IEvent
+        {
+        }
+    }
+#pragma warning restore  612, 618
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event_transport_mutators_should_not_be_called.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/InMemory/When_raising_an_in_memory_event_transport_mutators_should_not_be_called.cs
@@ -1,0 +1,77 @@
+﻿namespace NServiceBus.AcceptanceTests.InMemory
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using MessageMutator;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+    public class When_raising_an_in_memory_event_transport_mutators_should_not_be_called : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Ensure_transport_mutators_should_not_be_called()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<InMemoryEndpoint>(b => b.Given((bus, c) => bus.InMemory.Raise<MyInMemoryEvent>(m => { })))
+                .Run();
+
+            Assert.False(context.MutateIncomingCalled);
+            Assert.False(context.MutateOutGoingCalled);
+        }
+
+        class Mutator : IMutateTransportMessages, INeedInitialization
+        {
+            public Context Context { get; set; }
+
+            public void MutateIncoming(TransportMessage transportMessage)
+            {
+                Context.MutateIncomingCalled = true;
+            }
+
+            public void MutateOutgoing(object[] messages, TransportMessage transportMessage)
+            {
+                Context.MutateOutGoingCalled = true;
+            }
+
+            public void Init()
+            {
+                Configure.Component<Mutator>(DependencyLifecycle.InstancePerCall);
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MutateOutGoingCalled { get; set; }
+            public bool MutateIncomingCalled { get; set; }
+        }
+
+        public class InMemoryEndpoint : EndpointConfigurationBuilder
+        {
+            public InMemoryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>());
+            }
+
+        }
+
+        public class MyEventHandler : IHandleMessages<MyInMemoryEvent>
+        {
+            public Context Context { get; set; }
+
+            public void Handle(MyInMemoryEvent messageThatIsEnlisted)
+            {
+            }
+        }
+
+
+        [Serializable]
+        public class MyInMemoryEvent : IEvent
+        {
+        }
+    }
+#pragma warning restore  612, 618
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/Issue_1980.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/Issue_1980.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class Issue_1980 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new V1Message())))
+                    .Done(c => c.V2MessageReceived)
+                    .Run();
+
+            Assert.IsTrue(context.V2MessageReceived);
+            Assert.IsFalse(context.V1MessageReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool V1MessageReceived { get; set; }
+            public bool V2MessageReceived { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    c => c.Configurer.ConfigureComponent<MutateIncomingMessages>(DependencyLifecycle.InstancePerCall));
+            }
+
+            class MutateIncomingMessages : IMutateIncomingMessages
+            {
+                public object MutateIncoming(object message)
+                {
+                    if (message is V1Message)
+                    {
+                        return new V2Message();
+                    }
+
+                    return message;
+                }
+            }
+
+            class V2MessageHandler : IHandleMessages<V2Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V2Message message)
+                {
+                    Context.V2MessageReceived = true;
+                }
+            }
+
+            class V1MessageHandler : IHandleMessages<V1Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V1Message message)
+                {
+                    Context.V1MessageReceived = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class V1Message : ICommand
+        {
+        }
+
+        [Serializable]
+        public class V2Message : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/When_defining_outgoing_message_mutators.cs
@@ -1,0 +1,95 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_defining_outgoing_message_mutators : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_applied_to_outgoing_messages()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<OutgoingMutatorEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeMutated())))
+                    .Done(c => c.MessageProcessed)
+                    .Run();
+
+            Assert.True(context.TransportMutatorCalled);
+            Assert.True(context.MessageMutatorCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageProcessed { get; set; }
+            public bool TransportMutatorCalled { get; set; }
+            public bool MessageMutatorCalled { get; set; }
+        }
+
+        public class OutgoingMutatorEndpoint : EndpointConfigurationBuilder
+        {
+            public OutgoingMutatorEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+
+            class MyTransportMessageMutator:IMutateOutgoingTransportMessages,INeedInitialization
+            {
+                public void MutateOutgoing(object[] messages, TransportMessage transportMessage)
+                {
+                    transportMessage.Headers["TransportMutatorCalled"] = true.ToString();
+                }
+
+                public void Init()
+                {
+                    Configure.Component<MyTransportMessageMutator>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            class MyMessageMutator : IMutateOutgoingMessages, INeedInitialization
+            {
+
+             
+                public object MutateOutgoing(object message)
+                {
+                    Headers.SetMessageHeader(message,"MessageMutatorCalled","true");
+
+                    return message;
+                }
+
+                public void Init()
+                {
+                    Configure.Component<MyMessageMutator>(DependencyLifecycle.InstancePerCall);
+                }
+
+            }
+
+            class MessageToBeMutatedHandler : IHandleMessages<MessageToBeMutated>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+
+                public void Handle(MessageToBeMutated message)
+                {
+                    Context.TransportMutatorCalled = Bus.CurrentMessageContext.Headers.ContainsKey("TransportMutatorCalled");
+                    Context.MessageMutatorCalled = Bus.CurrentMessageContext.Headers.ContainsKey("MessageMutatorCalled");
+
+                    Context.MessageProcessed = true;
+
+                }
+            }
+
+        }
+
+        [Serializable]
+        public class MessageToBeMutated : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/When_outgoing_mutator_replaces_message_instance.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/MessageMutators/When_outgoing_mutator_replaces_message_instance.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_outgoing_mutator_replaces_message_instance : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_sent_should_be_new_instance()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new V1Message())))
+                .Done(c => c.V2MessageReceived)
+                .Run();
+
+            Assert.IsTrue(context.V2MessageReceived);
+            Assert.IsFalse(context.V1MessageReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool V1MessageReceived { get; set; }
+            public bool V2MessageReceived { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    c => c.Configurer.ConfigureComponent<MutateOutgoingMessages>(DependencyLifecycle.InstancePerCall));
+            }
+
+            class MutateOutgoingMessages : IMutateOutgoingMessages
+            {
+                public object MutateOutgoing(object message)
+                {
+                    if (message is V1Message)
+                    {
+                        return new V2Message();
+                    }
+
+                    return message;
+                }
+            }
+
+            class V2MessageHandler : IHandleMessages<V2Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V2Message message)
+                {
+                    Context.V2MessageReceived = true;
+                }
+            }
+
+            class V1MessageHandler : IHandleMessages<V1Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V1Message message)
+                {
+                    Context.V1MessageReceived = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class V1Message : ICommand
+        {
+        }
+
+        [Serializable]
+        public class V2Message : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
@@ -1,0 +1,27 @@
+namespace NServiceBus.AcceptanceTests
+{
+    using AcceptanceTesting.Customization;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Base class for all the NSB test that sets up our conventions
+    /// </summary>
+    [TestFixture]
+// ReSharper disable once PartialTypeWithSinglePart
+    public abstract partial class NServiceBusAcceptanceTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            Conventions.EndpointNamingConvention= t =>
+                {
+                    var baseNs = typeof (NServiceBusAcceptanceTest).Namespace;
+                    var testName = GetType().Name;
+                    return t.FullName.Replace(baseNs + ".", "").Replace(testName + "+", "")
+                            + "." + System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(testName).Replace("_", "");
+                };
+
+            Conventions.DefaultRunDescriptor = () => ScenarioDescriptors.Transports.Default;
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/FilteringWhatGetsAudited.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/FilteringWhatGetsAudited.cs
@@ -1,0 +1,138 @@
+﻿
+namespace NServiceBus.AcceptanceTests.PipelineExtension
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Audit;
+    using NUnit.Framework;
+    using Pipeline;
+    using Pipeline.Contexts;
+
+    /// <summary>
+    /// This is a demo on how pipeline overrides can be used to control which messages that gets audited by NServiceBus
+    /// </summary>
+    public class FilteringWhatGetsAudited : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void RunDemo()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<UserEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                .WithEndpoint<AuditSpy>()
+                .Done(c => c.IsMessageHandlingComplete)
+                .Run();
+
+            Assert.IsFalse(context.MessageAudited);
+        }
+
+
+        public class UserEndpoint : EndpointConfigurationBuilder
+        {
+
+            public UserEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<AuditSpy>();
+
+            }
+
+            class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+                }
+            }
+
+#pragma warning disable 618
+            class MyFilteringAuditBehavior : IBehavior<ReceivePhysicalMessageContext>,
+                IBehavior<ReceiveLogicalMessageContext>
+            {
+                public MessageAuditer MessageAuditer { get; set; }
+
+                public void Invoke(ReceivePhysicalMessageContext context, Action next)
+                {
+                    var auditResult = new AuditFilterResult();
+                    context.Set(auditResult);
+                    next();
+
+                    //note: and rule operating on the raw TransportMessage can be applied here if needed.
+                    // Access to the message is through: context.PhysicalMessage. Eg:  context.PhysicalMessage.Headers.ContainsKey("NServiceBus.ControlMessage")
+                    if (auditResult.DoNotAuditMessage)
+                    {
+                        return;
+                    }
+                    MessageAuditer.ForwardMessageToAuditQueue(context.PhysicalMessage);
+                }
+
+                public void Invoke(ReceiveLogicalMessageContext context, Action next)
+                {
+                    //filter out messages of type MessageToBeAudited
+                    if (context.LogicalMessage.MessageType == typeof(MessageToBeAudited))
+                    {
+                        context.Get<AuditFilterResult>().DoNotAuditMessage = true;
+                    }
+                }
+
+                class AuditFilterResult
+                {
+                    public bool DoNotAuditMessage { get; set; }
+                }
+
+
+                //here we inject our behavior
+                class AuditFilteringOverride : PipelineOverride
+                {
+                    public override void Override(BehaviorList<ReceivePhysicalMessageContext> behaviorList)
+                    {
+                        //we replace the default audit behavior with out own
+                        behaviorList.Replace<AuditBehavior, MyFilteringAuditBehavior>();
+                    }
+
+                    public override void Override(BehaviorList<ReceiveLogicalMessageContext> behaviorList)
+                    {
+                        //and also hook into to logical receive pipeline to make filtering on message types easier
+                        behaviorList.Add<MyFilteringAuditBehavior>();
+                    }
+                }
+
+#pragma warning restore 618
+            }
+        }
+
+        public class AuditSpy : EndpointConfigurationBuilder
+        {
+
+            public AuditSpy()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.MessageAudited = true;
+                }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsMessageHandlingComplete { get; set; }
+            public bool MessageAudited { get; set; }
+        }
+
+
+        [Serializable]
+        public class MessageToBeAudited : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/MutingHandlerExceptions.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/MutingHandlerExceptions.cs
@@ -1,0 +1,121 @@
+﻿
+namespace NServiceBus.AcceptanceTests.PipelineExtension
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using Pipeline;
+    using Pipeline.Contexts;
+    using Unicast.Behaviors;
+
+    /// <summary>
+    /// This is a demo on how pipeline overrides can be used to control which messages that gets audited by NServiceBus
+    /// </summary>
+    public class MutingHandlerExceptions : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void RunDemo()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<EndpointWithCustomExceptionMuting>(b => b.Given(bus => bus.SendLocal(new MessageThatWillBlowUpButExWillBeMuted())))
+                .WithEndpoint<AuditSpy>()
+                .Done(c => c.IsMessageHandlingComplete)
+                .Run();
+
+            Assert.IsTrue(context.MessageAudited);
+        }
+
+
+        public class EndpointWithCustomExceptionMuting : EndpointConfigurationBuilder
+        {
+
+            public EndpointWithCustomExceptionMuting()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<AuditSpy>();
+
+            }
+
+            class Handler : IHandleMessages<MessageThatWillBlowUpButExWillBeMuted>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageThatWillBlowUpButExWillBeMuted message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+
+                    throw new Exception("Lets filter on this text");
+                }
+            }
+
+#pragma warning disable 618
+            class MyExceptionFilteringBehavior : IBehavior<HandlerInvocationContext>
+            {
+                public void Invoke(HandlerInvocationContext context, Action next)
+                {
+                    try
+                    {
+                        //invoke the handler/rest of the pipeline
+                        next();
+                    }
+                    //catch specifix exceptions or
+                    catch (Exception ex)
+                    {
+                        //modify this to your liking
+                        if (ex.Message == "Lets filter on this text")
+                            return;
+
+                        throw;
+                    }
+                }
+
+
+                //here we inject our behavior
+                class MyExceptionFilteringOverride : PipelineOverride
+                {
+                    public override void Override(BehaviorList<HandlerInvocationContext> behaviorList)
+                    {
+                        //add our behavior to the pipeline just before NSB actually calls the handlers
+                        behaviorList.InsertBefore<InvokeHandlersBehavior, MyExceptionFilteringBehavior>();
+                    }
+                }
+
+#pragma warning restore 618
+
+            }
+        }
+
+        public class AuditSpy : EndpointConfigurationBuilder
+        {
+
+            public AuditSpy()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AuditMessageHandler : IHandleMessages<MessageThatWillBlowUpButExWillBeMuted>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageThatWillBlowUpButExWillBeMuted message)
+                {
+                    MyContext.MessageAudited = true;
+                }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsMessageHandlingComplete { get; set; }
+            public bool MessageAudited { get; set; }
+        }
+
+
+        [Serializable]
+        public class MessageThatWillBlowUpButExWillBeMuted : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/MutingHandlerExceptions.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/MutingHandlerExceptions.cs
@@ -1,121 +1,121 @@
 ﻿
-namespace NServiceBus.AcceptanceTests.PipelineExtension
-{
-    using System;
-    using AcceptanceTesting;
-    using EndpointTemplates;
-    using NUnit.Framework;
-    using Pipeline;
-    using Pipeline.Contexts;
-    using Unicast.Behaviors;
-
-    /// <summary>
-    /// This is a demo on how pipeline overrides can be used to control which messages that gets audited by NServiceBus
-    /// </summary>
-    public class MutingHandlerExceptions : NServiceBusAcceptanceTest
-    {
-        [Test]
-        public void RunDemo()
-        {
-            var context = new Context();
-            Scenario.Define(context)
-                .WithEndpoint<EndpointWithCustomExceptionMuting>(b => b.Given(bus => bus.SendLocal(new MessageThatWillBlowUpButExWillBeMuted())))
-                .WithEndpoint<AuditSpy>()
-                .Done(c => c.IsMessageHandlingComplete)
-                .Run();
-
-            Assert.IsTrue(context.MessageAudited);
-        }
-
-
-        public class EndpointWithCustomExceptionMuting : EndpointConfigurationBuilder
-        {
-
-            public EndpointWithCustomExceptionMuting()
-            {
-                EndpointSetup<DefaultServer>()
-                    .AuditTo<AuditSpy>();
-
-            }
-
-            class Handler : IHandleMessages<MessageThatWillBlowUpButExWillBeMuted>
-            {
-                public Context MyContext { get; set; }
-
-                public void Handle(MessageThatWillBlowUpButExWillBeMuted message)
-                {
-                    MyContext.IsMessageHandlingComplete = true;
-
-                    throw new Exception("Lets filter on this text");
-                }
-            }
-
-#pragma warning disable 618
-            class MyExceptionFilteringBehavior : IBehavior<HandlerInvocationContext>
-            {
-                public void Invoke(HandlerInvocationContext context, Action next)
-                {
-                    try
-                    {
-                        //invoke the handler/rest of the pipeline
-                        next();
-                    }
-                    //catch specifix exceptions or
-                    catch (Exception ex)
-                    {
-                        //modify this to your liking
-                        if (ex.Message == "Lets filter on this text")
-                            return;
-
-                        throw;
-                    }
-                }
-
-
-                //here we inject our behavior
-                class MyExceptionFilteringOverride : PipelineOverride
-                {
-                    public override void Override(BehaviorList<HandlerInvocationContext> behaviorList)
-                    {
-                        //add our behavior to the pipeline just before NSB actually calls the handlers
-                        behaviorList.InsertBefore<InvokeHandlersBehavior, MyExceptionFilteringBehavior>();
-                    }
-                }
-
-#pragma warning restore 618
-
-            }
-        }
-
-        public class AuditSpy : EndpointConfigurationBuilder
-        {
-
-            public AuditSpy()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
-            class AuditMessageHandler : IHandleMessages<MessageThatWillBlowUpButExWillBeMuted>
-            {
-                public Context MyContext { get; set; }
-
-                public void Handle(MessageThatWillBlowUpButExWillBeMuted message)
-                {
-                    MyContext.MessageAudited = true;
-                }
-            }
-        }
-
-        public class Context : ScenarioContext
-        {
-            public bool IsMessageHandlingComplete { get; set; }
-            public bool MessageAudited { get; set; }
-        }
-
-
-        [Serializable]
-        public class MessageThatWillBlowUpButExWillBeMuted : IMessage
-        {
-        }
-    }
-}
+//namespace NServiceBus.AcceptanceTests.PipelineExtension
+//{
+//    using System;
+//    using AcceptanceTesting;
+//    using EndpointTemplates;
+//    using NUnit.Framework;
+//    using Pipeline;
+//    using Pipeline.Contexts;
+//    using Unicast.Behaviors;
+//
+//    /// <summary>
+//    /// This is a demo on how pipeline overrides can be used to control which messages that gets audited by NServiceBus
+//    /// </summary>
+//    public class MutingHandlerExceptions : NServiceBusAcceptanceTest
+//    {
+//        [Test]
+//        public void RunDemo()
+//        {
+//            var context = new Context();
+//            Scenario.Define(context)
+//                .WithEndpoint<EndpointWithCustomExceptionMuting>(b => b.Given(bus => bus.SendLocal(new MessageThatWillBlowUpButExWillBeMuted())))
+//                .WithEndpoint<AuditSpy>()
+//                .Done(c => c.IsMessageHandlingComplete)
+//                .Run();
+//
+//            Assert.IsTrue(context.MessageAudited);
+//        }
+//
+//
+//        public class EndpointWithCustomExceptionMuting : EndpointConfigurationBuilder
+//        {
+//
+//            public EndpointWithCustomExceptionMuting()
+//            {
+//                EndpointSetup<DefaultServer>()
+//                    .AuditTo<AuditSpy>();
+//
+//            }
+//
+//            class Handler : IHandleMessages<MessageThatWillBlowUpButExWillBeMuted>
+//            {
+//                public Context MyContext { get; set; }
+//
+//                public void Handle(MessageThatWillBlowUpButExWillBeMuted message)
+//                {
+//                    MyContext.IsMessageHandlingComplete = true;
+//
+//                    throw new Exception("Lets filter on this text");
+//                }
+//            }
+//
+//#pragma warning disable 618
+//            class MyExceptionFilteringBehavior : IBehavior<HandlerInvocationContext>
+//            {
+//                public void Invoke(HandlerInvocationContext context, Action next)
+//                {
+//                    try
+//                    {
+//                        //invoke the handler/rest of the pipeline
+//                        next();
+//                    }
+//                    //catch specifix exceptions or
+//                    catch (Exception ex)
+//                    {
+//                        //modify this to your liking
+//                        if (ex.Message == "Lets filter on this text")
+//                            return;
+//
+//                        throw;
+//                    }
+//                }
+//
+//
+//                //here we inject our behavior
+//                class MyExceptionFilteringOverride : PipelineOverride
+//                {
+//                    public override void Override(BehaviorList<HandlerInvocationContext> behaviorList)
+//                    {
+//                        //add our behavior to the pipeline just before NSB actually calls the handlers
+//                        behaviorList.InsertBefore<InvokeHandlersBehavior, MyExceptionFilteringBehavior>();
+//                    }
+//                }
+//
+//#pragma warning restore 618
+//
+//            }
+//        }
+//
+//        public class AuditSpy : EndpointConfigurationBuilder
+//        {
+//
+//            public AuditSpy()
+//            {
+//                EndpointSetup<DefaultServer>();
+//            }
+//
+//            class AuditMessageHandler : IHandleMessages<MessageThatWillBlowUpButExWillBeMuted>
+//            {
+//                public Context MyContext { get; set; }
+//
+//                public void Handle(MessageThatWillBlowUpButExWillBeMuted message)
+//                {
+//                    MyContext.MessageAudited = true;
+//                }
+//            }
+//        }
+//
+//        public class Context : ScenarioContext
+//        {
+//            public bool IsMessageHandlingComplete { get; set; }
+//            public bool MessageAudited { get; set; }
+//        }
+//
+//
+//        [Serializable]
+//        public class MessageThatWillBlowUpButExWillBeMuted : IMessage
+//        {
+//        }
+//    }
+//}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/SkipDeserialization.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PipelineExtension/SkipDeserialization.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.AcceptanceTests.PipelineExtension
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using Pipeline;
+    using Pipeline.Contexts;
+    using Unicast.Messages;
+
+    //This is a demo on how the pipeline overrides can be used to create endpoints that doesn't deserialize incoming messages and there by
+    // allows the user to handle the raw transport message. This replaces the old feature on the UnicastBus where SkipDeserialization could be set to tru
+    public class SkipDeserialization : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void RunDemo()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonSerializingEndpoint>(
+                        b => b.Given(bus => bus.SendLocal(new SomeMessage())))
+                    .Done(c => c.GotTheRawMessage)
+                    .Run();
+        }
+
+        public class NonSerializingEndpoint : EndpointConfigurationBuilder
+        {
+            public NonSerializingEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+
+#pragma warning disable 618
+            //first we override the default "extraction" behavior
+            class MyOverride : PipelineOverride
+            {
+                public override void Override(BehaviorList<ReceivePhysicalMessageContext> behaviorList)
+                {
+                    behaviorList.Replace<ExtractLogicalMessagesBehavior, MyRawMessageHandler>();
+                }
+            }
+
+            //and then we handle the physical message our self
+            class MyRawMessageHandler:IBehavior<ReceivePhysicalMessageContext>
+            {
+                public Context Context { get; set; }
+
+                public void Invoke(ReceivePhysicalMessageContext context, Action next)
+                {
+                    var transportMessage = context.PhysicalMessage;
+
+                    Assert.True(transportMessage.Headers[Headers.EnclosedMessageTypes].Contains(typeof(SomeMessage).Name));
+
+                    Context.GotTheRawMessage = true;
+                }
+            }
+#pragma warning restore 618
+
+            class ThisHandlerWontGetInvoked:IHandleMessages<SomeMessage>
+            {
+                public void Handle(SomeMessage message)
+                {
+                    Assert.Fail();
+                }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheRawMessage { get; set; }
+        }
+
+        [Serializable]
+        public class SomeMessage : ICommand
+        {
+
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/Subscriptions.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/Subscriptions.cs
@@ -1,0 +1,24 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using Features;
+    using Unicast.Subscriptions;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
+    [Serializable]
+    public class Subscriptions
+    {
+        public static Action<Action<SubscriptionEventArgs>> OnEndpointSubscribed = actionToPerform =>
+            {
+                if (Feature.IsEnabled<MessageDrivenSubscriptions>())
+                {
+                    Configure.Instance.Builder.Build<MessageDrivenSubscriptionManager>().ClientSubscribed +=
+                        (sender, args) =>
+                        {
+                            actionToPerform(args);
+                        };
+                }
+            };
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_multi_subscribing_to_a_polymorphic_event.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_multi_subscribing_to_a_polymorphic_event.cs
@@ -1,0 +1,127 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_multi_subscribing_to_a_polymorphic_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Both_events_should_be_delivered()
+        {
+            var rootContext = new Context();
+
+            Scenario.Define(rootContext)
+                    .WithEndpoint<Publisher1>(b => b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(args =>
+                {
+                    if (args.MessageType.Contains(typeof(IMyEvent).Name))
+                    {
+                        context.SubscribedToIMyEvent = true;
+                    }
+
+                    if (args.MessageType.Contains(typeof(MyEvent2).Name))
+                    {
+                        context.SubscribedToMyEvent2 = true;
+                    }
+                }))
+                    .When(c => c.SubscribedToIMyEvent && c.SubscribedToMyEvent2, bus => bus.Publish(new MyEvent1())))
+                    .WithEndpoint<Publisher2>(b => b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(args =>
+                {
+                    if (args.MessageType.Contains(typeof(IMyEvent).Name))
+                    {
+                        context.SubscribedToIMyEvent = true;
+                    }
+
+                    if (args.MessageType.Contains(typeof(MyEvent2).Name))
+                    {
+                        context.SubscribedToMyEvent2 = true;
+                    }
+                }))
+                    .When(c => c.SubscribedToIMyEvent && c.SubscribedToMyEvent2, bus => bus.Publish(new MyEvent2())))
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                    {
+                        bus.Subscribe<IMyEvent>();
+                        bus.Subscribe<MyEvent2>();
+
+                        if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                        {
+                            context.SubscribedToIMyEvent = true;
+                            context.SubscribedToMyEvent2 = true;
+                        }
+                    }))
+                    .Done(c => c.SubscriberGotIMyEvent && c.SubscriberGotMyEvent2)
+                    .Run();
+
+            Assert.True(rootContext.SubscriberGotIMyEvent);
+            Assert.True(rootContext.SubscriberGotMyEvent2);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SubscriberGotIMyEvent { get; set; }
+            public bool SubscriberGotMyEvent2 { get; set; }
+            public bool SubscribedToIMyEvent { get; set; }
+            public bool SubscribedToMyEvent2 { get; set; }
+        }
+
+        public class Publisher1 : EndpointConfigurationBuilder
+        {
+            public Publisher1()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Publisher2 : EndpointConfigurationBuilder
+        {
+            public Publisher2()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<IMyEvent>(typeof(Publisher1))
+                    .AddMapping<MyEvent2>(typeof(Publisher2));
+            }
+
+            public class MyEventHandler : IHandleMessages<IMyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(IMyEvent messageThatIsEnlisted)
+                {
+                    if (messageThatIsEnlisted is MyEvent2)
+                    {
+                        Context.SubscriberGotMyEvent2 = true;
+                    }
+                    else
+                    {
+                        Context.SubscriberGotIMyEvent = true;
+                    }
+                }
+            }
+        }
+
+        
+        [Serializable]
+        public class MyEvent1 : IMyEvent
+        {
+        }
+
+        [Serializable]
+        public class MyEvent2 : IMyEvent
+        {
+        }
+
+        public interface IMyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event.cs
@@ -1,0 +1,166 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_an_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Issue_1851()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                        {
+                            if (s.SubscriberReturnAddress.Queue.Contains("Subscriber3"))
+                            {
+                                context.Subscriber3Subscribed = true;
+                            }
+                        }))
+                        .When(c => c.Subscriber3Subscribed, bus => bus.Publish<IFoo>())
+                     )
+                    .WithEndpoint<Subscriber3>(b => b.Given((bus, context) =>
+                    {
+                        bus.Subscribe<IFoo>();
+
+                        if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                        {
+                            context.Subscriber3Subscribed = true;
+                        }
+                    }))
+                      
+                    .Done(c => c.Subscriber3GotTheEvent)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.Subscriber3GotTheEvent))
+                    .Run();
+        }
+
+        [Test]
+        public void Should_be_delivered_to_all_subscribers()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                        {
+                            if (s.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                                context.Subscriber1Subscribed = true;
+
+                            if (s.SubscriberReturnAddress.Queue.Contains("Subscriber2"))
+                                context.Subscriber2Subscribed = true;
+                        }))
+                        .When(c => c.Subscriber1Subscribed && c.Subscriber2Subscribed, bus => bus.Publish(new MyEvent()))
+                     )
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<MyEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.Subscriber1Subscribed = true;
+                        }))
+                      .WithEndpoint<Subscriber2>(b => b.Given((bus, context) =>
+                      {
+                          bus.Subscribe<MyEvent>();
+
+                          if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                              context.Subscriber2Subscribed = true;
+                      }))
+                    .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c =>
+                    {
+                        Assert.True(c.Subscriber1GotTheEvent);
+                        Assert.True(c.Subscriber2GotTheEvent);
+                    })
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+            public bool Subscriber2GotTheEvent { get; set; }
+            public bool Subscriber3GotTheEvent { get; set; }
+            public bool Subscriber1Subscribed { get; set; }
+            public bool Subscriber2Subscribed { get; set; }
+            public bool Subscriber3Subscribed { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber3 : EndpointConfigurationBuilder
+        {
+            public Subscriber3()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<IFoo>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<IFoo>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(IFoo messageThatIsEnlisted)
+                {
+                    Context.Subscriber3GotTheEvent = true;
+                }
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                        .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber2GotTheEvent = true;
+                }
+            }
+        }
+
+        public interface IFoo : IEvent
+        {
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_using_a_broker_transport_with_centralized_routing.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_using_a_broker_transport_with_centralized_routing.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_an_event_using_a_broker_transport_with_centralized_routing : NServiceBusAcceptanceTest
+    {
+        [Test, Ignore] // Ignore because, test this test is unreliable. Passed on the build server without the core fix!
+        public void Should_be_delivered_to_allsubscribers_without_the_need_for_config()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<CentralizedPublisher>
+                    (b => b.When(c => c.IsSubscriptionProcessedForSub1 && c.IsSubscriptionProcessedForSub2, bus => bus.Publish(new MyEvent())))
+                    .WithEndpoint<CentralizedSubscriber1>(b => b.Given((bus, context) =>
+                    {
+                      context.IsSubscriptionProcessedForSub1 = true;
+                    }))
+                    .WithEndpoint<CentralizedSubscriber2>(b => b.Given((bus, context) =>
+                    {
+                        context.IsSubscriptionProcessedForSub2 = true;
+                    }))
+                    .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
+                    .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())
+                    .Should(c =>
+                    {
+                        Assert.True(c.Subscriber1GotTheEvent);
+                        Assert.True(c.Subscriber2GotTheEvent);
+                    })
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+            public bool Subscriber2GotTheEvent { get; set; }
+
+            public bool IsSubscriptionProcessedForSub1 { get; set; }
+            public bool IsSubscriptionProcessedForSub2 { get; set; }
+        }
+
+        public class CentralizedPublisher : EndpointConfigurationBuilder
+        {
+            public CentralizedPublisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class CentralizedSubscriber1 : EndpointConfigurationBuilder
+        {
+            public CentralizedSubscriber1()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        public class CentralizedSubscriber2 : EndpointConfigurationBuilder
+        {
+            public CentralizedSubscriber2()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber2GotTheEvent = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_only_local_messagehandlers.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_only_local_messagehandlers.cs
@@ -1,0 +1,104 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_an_event_with_only_local_messagehandlers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_trigger_the_catch_all_handler_for_message_driven_subscriptions()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<MessageDrivenPublisher>(b =>
+                                             b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                                                 {
+                                                     context.LocalEndpointSubscribed = true;
+                                                 }))
+                                              .When(c => c.LocalEndpointSubscribed, bus => bus.Publish(new EventHandledByLocalEndpoint()))
+                )
+                    .Done(c => c.CatchAllHandlerGotTheMessage)
+                    .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                    .Should(c => Assert.True(c.CatchAllHandlerGotTheMessage))
+
+                    .Run();
+        }
+
+        [Test]
+        public void Should_trigger_the_catch_all_handler_for_publishers_with_centralized_pubsub()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<CentralizedStoragePublisher>(b => b.When(c => c.EndpointsStarted, (bus, context) => bus.Publish(new EventHandledByLocalEndpoint())))
+                    .Done(c => c.CatchAllHandlerGotTheMessage)
+                    .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>(Transports.ActiveMQ)) //exclude active since the support for polymorphic routing is not implemented
+                    .Should(c => Assert.True(c.CatchAllHandlerGotTheMessage))
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            
+            public bool CatchAllHandlerGotTheMessage { get; set; }
+
+            public bool LocalEndpointSubscribed { get; set; }
+        }
+
+        public class MessageDrivenPublisher : EndpointConfigurationBuilder
+        {
+            public MessageDrivenPublisher()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<EventHandledByLocalEndpoint>(typeof(MessageDrivenPublisher)); //an explicit mapping is needed
+            }
+
+            class CatchAllHandler:IHandleMessages<IEvent> //not enough for auto subscribe to work
+            {
+                public Context Context { get; set; }
+                public void Handle(IEvent message)
+                {
+                    Context.CatchAllHandlerGotTheMessage = true;
+                }
+            }
+
+            class DummyHandler : IHandleMessages<EventHandledByLocalEndpoint> //explicit handler for the event is needed
+            {
+                public Context Context { get; set; }
+                public void Handle(EventHandledByLocalEndpoint message)
+                {
+                }
+            }
+        }
+
+        public class CentralizedStoragePublisher : EndpointConfigurationBuilder
+        {
+            public CentralizedStoragePublisher()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.AutoSubscribe(s => s.DoNotRequireExplicitRouting()));
+            }
+
+            class CatchAllHandler : IHandleMessages<IEvent> 
+            {
+                public Context Context { get; set; }
+                public void Handle(IEvent message)
+                {
+                    Context.CatchAllHandlerGotTheMessage = true;
+                }
+            }
+
+            class DummyHandler : IHandleMessages<EventHandledByLocalEndpoint> //explicit handler for the event is needed
+            {
+                public Context Context { get; set; }
+                public void Handle(EventHandledByLocalEndpoint message)
+                {
+                }
+            }
+        }
+        [Serializable]
+        public class EventHandledByLocalEndpoint : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_overridden_local_address.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_overridden_local_address.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_an_event_with_overridden_local_address : NServiceBusAcceptanceTest
+    {
+        [Test, Explicit("This test fails against RabbitMQ")]
+        public void Should_be_delivered_to_all_subscribers()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher>(b =>
+                        b.Given((bus, context) =>
+                            Subscriptions.OnEndpointSubscribed(s =>
+                            {
+                                if (s.SubscriberReturnAddress.Queue.Contains("myinputqueue"))
+                                    context.Subscriber1Subscribed = true;
+                            }))
+                        .When(c => c.Subscriber1Subscribed, bus => bus.Publish(new MyEvent()))
+                     )
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<MyEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.Subscriber1Subscribed = true;
+                        }))
+                    .Done(c => c.Subscriber1GotTheEvent)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.Subscriber1GotTheEvent))
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+            public bool Subscriber1Subscribed { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class OverrideLocalAddress : IWantToRunBeforeConfiguration
+            {
+                public void Init()
+                {
+                    Address.InitializeLocalAddress("myinputqueue");
+                }
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_the_subscriber_scaled_out.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_publishing_an_event_with_the_subscriber_scaled_out.cs
@@ -1,0 +1,119 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+    using Unicast.Subscriptions;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
+    public class When_publishing_an_event_with_the_subscriber_scaled_out : NServiceBusAcceptanceTest
+    {
+        static string Server1 = "Server1";
+        static string Server2 = "Server2";
+
+        [Test]//https://github.com/NServiceBus/NServiceBus/issues/1101
+        public void Should_only_publish_one_event()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                            {
+                                if (s.SubscriberReturnAddress.Queue != "MyEndpoint")
+                                    return;
+
+                                context.NumberOfSubscriptionsReceived++;
+                            }))
+                        .When(c => c.NumberOfSubscriptionsReceived >= 2, (bus, c) =>
+                            {
+                                c.SubscribersOfTheEvent = Configure.Instance.Builder.Build<ISubscriptionStorage>()
+                                                                  .GetSubscriberAddressesForMessage(new[] { new MessageType(typeof(MyEvent)) }).Select(a => a.ToString()).ToList();
+                            })
+                     )
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<MyEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.NumberOfSubscriptionsReceived++;
+                        }))
+                      .WithEndpoint<Subscriber2>(b => b.Given((bus, context) =>
+                      {
+                          bus.Subscribe<MyEvent>();
+
+                          if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                              context.NumberOfSubscriptionsReceived++;
+                      }))
+                    .Done(c => c.SubscribersOfTheEvent != null)
+                    .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>(Transports.Msmq)
+                        .For<AllSubscriptionStorages>(SubscriptionStorages.Msmq))
+                    .Should(c => Assert.AreEqual(1, c.SubscribersOfTheEvent.Count(), "There should only be one logical subscriber"))
+                    .MaxTestParallelism(1)//we force the endpoint names so we can't run this is parallel
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int NumberOfSubscriptionsReceived { get; set; }
+
+            public IEnumerable<string> SubscribersOfTheEvent { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<MyEvent>(typeof (Publisher))
+                    .CustomMachineName(Server1)
+                    .CustomEndpointName("MyEndpoint");
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                }
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                        .AddMapping<MyEvent>(typeof(Publisher))
+                        .CustomMachineName(Server2)
+                        .CustomEndpointName("MyEndpoint");
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_subscribing_to_a_base_event_from_different_publishers.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_subscribing_to_a_base_event_from_different_publishers.cs
@@ -1,0 +1,113 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_subscribing_to_a_base_event_from_different_publishers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void should_receive_events_from_all_publishers()
+        {
+            var cc = new Context();
+
+            Scenario.Define(cc)
+               .WithEndpoint<Publisher1>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                        {
+                            if (s.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                                context.SubscribedToPublisher1 = true;
+                        }))
+                        .When(c => c.SubscribedToPublisher1, bus => bus.Publish(new DerivedEvent1()))
+                     )
+                .WithEndpoint<Publisher2>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                        {
+                            if (s.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                                context.SubscribedToPublisher2 = true;
+                        }))
+                        .When(c => c.SubscribedToPublisher2, bus => bus.Publish(new DerivedEvent2()))
+                     )
+               .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+               {
+                   if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                   {
+                       context.SubscribedToPublisher1 = true;
+                       context.SubscribedToPublisher2 = true;
+                   }
+               }))
+               .Done(c => c.GotTheEventFromPublisher1 && c.GotTheEventFromPublisher2)
+               .Run();
+
+            Assert.True(cc.GotTheEventFromPublisher1);
+            Assert.True(cc.GotTheEventFromPublisher2);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheEventFromPublisher1 { get; set; }
+            public bool GotTheEventFromPublisher2 { get; set; }
+            public bool SubscribedToPublisher1 { get; set; }
+            public bool SubscribedToPublisher2 { get; set; }
+
+        }
+
+        public class Publisher1 : EndpointConfigurationBuilder
+        {
+            public Publisher1()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Publisher2 : EndpointConfigurationBuilder
+        {
+            public Publisher2()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Enable<AutoSubscribe>())
+                    .AddMapping<DerivedEvent1>(typeof(Publisher1))
+                    .AddMapping<DerivedEvent2>(typeof(Publisher2));
+            }
+
+            public class BaseEventHandler : IHandleMessages<BaseEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(BaseEvent message)
+                {
+                    if (message.GetType().FullName.Contains("DerivedEvent1"))
+                        Context.GotTheEventFromPublisher1 = true;
+                    if (message.GetType().FullName.Contains("DerivedEvent2"))
+                        Context.GotTheEventFromPublisher2 = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class BaseEvent : IEvent
+        {
+        }
+
+        [Serializable]
+        public class DerivedEvent1 : BaseEvent
+        {
+
+        }
+
+        [Serializable]
+        public class DerivedEvent2 : BaseEvent
+        {
+
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_subscribing_to_a_polymorphic_event.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/PubSub/When_subscribing_to_a_polymorphic_event.cs
@@ -1,0 +1,124 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
+    public class When_subscribing_to_a_polymorphic_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Event_should_be_delivered()
+        {
+            var cc = new Context();
+
+            Scenario.Define(cc)
+                    .WithEndpoint<Publisher>(b => b.Given((bus, context) => EnableNotificationsOnSubscribe(context))
+                    .When(c => c.Subscriber1Subscribed && c.Subscriber2Subscribed, bus => bus.Publish(new MyEvent())))
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<IMyEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.Subscriber1Subscribed = true;
+                        }))
+                    .WithEndpoint<Subscriber2>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<MyEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.Subscriber2Subscribed = true;
+                        }))
+                    .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
+                    .Run();
+
+            Assert.True(cc.Subscriber1GotTheEvent);
+            Assert.True(cc.Subscriber2GotTheEvent);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+
+            public bool Subscriber2GotTheEvent { get; set; }
+
+            public int NumberOfSubscribers { get; set; }
+
+            public bool Subscriber1Subscribed { get; set; }
+
+            public bool Subscriber2Subscribed { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c=>Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<IMyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<IMyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(IMyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                        .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber2GotTheEvent = true;
+                }
+            }
+        }
+        static void EnableNotificationsOnSubscribe(Context context)
+        {
+            if (Feature.IsEnabled<MessageDrivenSubscriptions>())
+            {
+                Configure.Instance.Builder.Build<MessageDrivenSubscriptionManager>().ClientSubscribed +=
+                    (sender, args) =>
+                    {
+                        if (args.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                            context.Subscriber1Subscribed = true;
+
+                        if (args.SubscriberReturnAddress.Queue.Contains("Subscriber2"))
+                            context.Subscriber2Subscribed = true;
+                    };
+            }
+        }
+
+        [Serializable]
+        public class MyEvent : IMyEvent
+        {
+        }
+
+        public interface IMyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Retries/When_doing_flr_with_default_settings.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Retries/When_doing_flr_with_default_settings.cs
@@ -1,0 +1,135 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using Config;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_doing_flr_with_default_settings : NServiceBusAcceptanceTest
+    {
+        public static Func<int> X = () => 5;
+            
+        [Test]
+        public void Should_do_X_retries_by_default_with_dtc_on()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried{ Id = context.Id })))
+                    .Done(c => c.HandedOverToSlr || c.NumberOfTimesInvoked > X())
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c => Assert.AreEqual(X(), c.NumberOfTimesInvoked, string.Format("The FLR should by default retry {0} times", X())))
+                    .Run();
+
+        }
+
+        [Test]
+        public void Should_do_X_retries_by_default_with_native_transactions()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<RetryEndpoint>(b =>
+                        {
+                            b.CustomConfig(c => Configure.Transactions.Advanced(a => a.DisableDistributedTransactions()));
+                            b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried { Id = context.Id }));
+                        })
+                    .Done(c => c.HandedOverToSlr || c.NumberOfTimesInvoked > X())
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.AreEqual(X(), c.NumberOfTimesInvoked, string.Format("The FLR should by default retry {0} times", X())))
+                    .Run(TimeSpan.FromMinutes(X()));
+
+        }
+
+        [Test]
+        public void Should_not_do_any_retries_if_transactions_are_off()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<RetryEndpoint>(b =>
+                    {
+                        b.CustomConfig(c => Configure.Transactions.Disable());
+                        b.Given((bus, context) =>
+                            {
+                                bus.SendLocal(new MessageToBeRetried { Id = context.Id });
+                                bus.SendLocal(new MessageToBeRetried { Id = context.Id, SecondMessage = true });
+                            });
+                    })
+                    .Done(c => c.SecondMessageReceived || c.NumberOfTimesInvoked > 1)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.AreEqual(1, c.NumberOfTimesInvoked, "No retries should be in use if transactions are off"))
+                    .Run();
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public int NumberOfTimesInvoked { get; set; }
+
+            public bool HandedOverToSlr { get; set; }
+
+            public bool SecondMessageReceived { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    c => c.Configurer.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance))
+                    .WithConfig<TransportConfig>(c => c.MaximumConcurrencyLevel = 1)
+                    .AllowExceptions();
+            }
+
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.HandedOverToSlr = true;
+                }
+
+                public void Init(Address address)
+                {
+
+                }
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageToBeRetried message)
+                {
+                    if (message.Id != Context.Id) return; // messages from previous test runs must be ignored
+
+                    if (message.SecondMessage)
+                    {
+                        Context.SecondMessageReceived = true;
+                        return;
+                    }
+
+                    Context.NumberOfTimesInvoked++;
+
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid Id { get; set; }
+
+            public bool SecondMessage { get; set; }
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Retries/When_message_fails_with_retries_set_to_0.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Retries/When_message_fails_with_retries_set_to_0.cs
@@ -1,0 +1,87 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using System.Collections.Generic;
+    using Config;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_message_fails_with_retries_set_to_0 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_retry_the_message_using_flr()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                    .Done(c => c.HandedOverToSlr)
+                    .Run();
+
+            Assert.AreEqual(1, context.NumberOfTimesInvoked,"No FLR should be in use if MaxRetries is set to 0");
+            Assert.True(context.HeadersOfTheFailedMessage[Headers.ProcessingEndpoint].Contains("RetryEndpoint"), "The receiver should attach its endpoint name as a header");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int NumberOfTimesInvoked { get; set; }
+
+            public bool HandedOverToSlr { get; set; }
+
+            public Dictionary<string, string> HeadersOfTheFailedMessage { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Configurer.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance))
+                    .WithConfig<TransportConfig>(c =>
+                        {
+                            c.MaxRetries = 0;
+                        })
+                        .AllowExceptions();
+            }
+
+            class CustomFaultManager: IManageMessageFailures
+            {
+                public Context  Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+                    
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.HandedOverToSlr = true;
+                    Context.HeadersOfTheFailedMessage = message.Headers;
+                }
+
+                public void Init(Address address)
+                {
+                    
+                }
+            }
+
+            class MessageToBeRetriedHandler:IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+                public void Handle(MessageToBeRetried message)
+                {
+                    Context.NumberOfTimesInvoked++;
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Retries/When_messages_fails_flr.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Retries/When_messages_fails_flr.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using Config;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_messages_fails_flr : NServiceBusAcceptanceTest
+    {
+        static TimeSpan SlrDelay = TimeSpan.FromSeconds(5);
+
+        [Test]
+        public void Should_be_moved_to_slr()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<SLREndpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried { Id = context.Id })))
+                    .Done(c => c.NumberOfTimesInvoked >= 2)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(context =>
+                        {
+                            Assert.GreaterOrEqual(1,context.NumberOfSlrRetriesPerformed, "The SLR should only do one retry");
+                            Assert.GreaterOrEqual(context.TimeOfSecondAttempt - context.TimeOfFirstAttempt,SlrDelay , "The SLR should delay the retry");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public int NumberOfTimesInvoked { get; set; }
+
+            public DateTime TimeOfFirstAttempt { get; set; }
+            public DateTime TimeOfSecondAttempt { get; set; }
+
+            public int NumberOfSlrRetriesPerformed { get; set; }
+        }
+
+        public class SLREndpoint : EndpointConfigurationBuilder
+        {
+            public SLREndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AllowExceptions()
+                    .WithConfig<TransportConfig>(c =>
+                        {
+                            c.MaxRetries = 0; //to skip the FLR
+                        })
+                        .WithConfig<SecondLevelRetriesConfig>(c =>
+                        {
+                            c.NumberOfRetries = 1;
+                            c.TimeIncrease = SlrDelay;
+                        });
+            }
+
+
+            class MessageToBeRetriedHandler:IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MessageToBeRetried message)
+                {
+                    if (message.Id != Context.Id) return; // ignore messages from previous test runs
+
+                    Context.NumberOfTimesInvoked++;
+
+                    if (Context.NumberOfTimesInvoked == 1)
+                        Context.TimeOfFirstAttempt = DateTime.UtcNow;
+
+                    if (Context.NumberOfTimesInvoked == 2)
+                    {
+                        Context.TimeOfSecondAttempt = DateTime.UtcNow;
+                    }
+
+                    Context.NumberOfSlrRetriesPerformed = int.Parse(Bus.CurrentMessageContext.Headers[Headers.Retries]); 
+                        
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Retries/When_sending_a_message_off_to_slr.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Retries/When_sending_a_message_off_to_slr.cs
@@ -1,0 +1,146 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using System.Linq;
+    using Config;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+#pragma warning disable 612, 618
+
+    public class When_sending_a_message_off_to_slr : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_preserve_the_original_body_for_regular_exceptions()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                    .Done(c => c.SlrChecksum != default(byte))
+                    .Run();
+
+            Assert.AreEqual(context.OriginalBodyChecksum, context.SlrChecksum, "The body of the message sent to slr should be the same as the original message coming off the queue");
+
+        }
+        [Test]
+        public void Should_preserve_the_original_body_for_serialization_exceptions()
+        {
+            var context = new Context
+                {
+                    SimulateSerializationException = true
+                };
+
+            Scenario.Define(context)
+                    .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                    .Done(c => c.SlrChecksum != default(byte))
+                    .Run();
+
+            Assert.AreEqual(context.OriginalBodyChecksum, context.SlrChecksum, "The body of the message sent to slr should be the same as the original message coming off the queue");
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public byte OriginalBodyChecksum { get; set; }
+
+            public byte SlrChecksum { get; set; }
+
+            public bool SimulateSerializationException { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Configurer.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance))
+                    .WithConfig<TransportConfig>(c =>
+                        {
+                            c.MaxRetries = 0;
+                        })
+                        .AllowExceptions();
+            }
+
+            class BodyMutator : IMutateTransportMessages, NServiceBus.INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+
+                    var originalBody = transportMessage.Body;
+
+                    Context.OriginalBodyChecksum = Checksum(originalBody);
+
+                    var decryptedBody = new byte[originalBody.Length];
+
+                    Buffer.BlockCopy(originalBody,0,decryptedBody,0,originalBody.Length);
+                   
+                    //decrypt
+                    decryptedBody[0]++;
+
+                    if (Context.SimulateSerializationException)
+                        decryptedBody[1]++;
+
+                    transportMessage.Body = decryptedBody;
+                }
+
+
+                public void MutateOutgoing(object[] messages, TransportMessage transportMessage)
+                {
+                    transportMessage.Body[0]--;
+                }
+
+                public void Init()
+                {
+                    Configure.Component<BodyMutator>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+                    Context.SlrChecksum = Checksum(message.Body);
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.SlrChecksum = Checksum(message.Body);
+                }
+
+                public void Init(Address address)
+                {
+
+                }
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public void Handle(MessageToBeRetried message)
+                {
+                    throw new Exception("Simulated exception");
+                }
+            }
+
+            public static byte Checksum(byte[] data)
+            {
+                var longSum = data.Sum(x => (long)x);
+                return unchecked((byte)longSum);
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+        }
+    }
+
+#pragma warning restore  612, 618
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/Issue_1819.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/Issue_1819.cs
@@ -1,0 +1,118 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class Issue_1819 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context { Id = Guid.NewGuid() };
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new StartSaga1 { ContextId = c.Id })))
+                    .Done(c => (c.Saga1TimeoutFired && c.Saga2TimeoutFired) || c.SagaNotFound)
+                    .Run(TimeSpan.FromSeconds(20));
+
+            Assert.IsFalse(context.SagaNotFound);
+            Assert.IsTrue(context.Saga1TimeoutFired);
+            Assert.IsTrue(context.Saga2TimeoutFired);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public bool Saga1TimeoutFired { get; set; }
+            public bool Saga2TimeoutFired { get; set; }
+            public bool SagaNotFound { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>, IHandleTimeouts<Saga2Timeout>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga1 message)
+                {
+                    if (message.ContextId != Context.Id) return;
+
+                    RequestTimeout(TimeSpan.FromSeconds(5), new Saga1Timeout { ContextId = Context.Id });
+                    RequestTimeout(new DateTime(2011, 10, 14, 23, 08, 0, DateTimeKind.Local), new Saga2Timeout { ContextId = Context.Id });
+                }
+
+                public void Timeout(Saga1Timeout state)
+                {
+                    MarkAsComplete();
+
+                    if (state.ContextId != Context.Id) return;
+                    Context.Saga1TimeoutFired = true;
+                }
+
+                public void Timeout(Saga2Timeout state)
+                {
+                    if (state.ContextId != Context.Id) return;
+                    Context.Saga2TimeoutFired = true;
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                }
+            }
+
+            public class SagaNotFound : IHandleSagaNotFound
+            {
+                public Context Context { get; set; }
+
+                public void Handle(object message)
+                {
+                    if (((dynamic)message).ContextId != Context.Id) return;
+
+                    Context.SagaNotFound = true;
+                }
+            }
+
+            public class CatchAllMessageHandler : IHandleMessages<object>
+            {
+                public void Handle(object message)
+                {
+
+                }
+            }
+
+            public class Foo : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.SpecifyFirst<CatchAllMessageHandler>();
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+            public Guid ContextId { get; set; }
+        }
+
+
+        public class Saga1Timeout
+        {
+            public Guid ContextId { get; set; }
+        }
+
+        public class Saga2Timeout
+        {
+            public Guid ContextId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/Issue_2044.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/Issue_2044.cs
@@ -1,0 +1,99 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class Issue_2044 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MessageToSaga())))
+                    .WithEndpoint<ReceiverWithSaga>()
+                    .Done(c => c.ReplyReceived)
+                    .Run();
+
+            Assert.IsTrue(context.ReplyReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool ReplyReceived { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MessageToSaga>(typeof(ReceiverWithSaga));
+            }
+
+            public class ReplyHandler : IHandleMessages<Reply>
+            {
+                public Context Context { get; set; }
+
+
+                public void Handle(Reply message)
+                {
+                    Context.ReplyReceived = true;
+                }
+            }
+        }
+
+        public class ReceiverWithSaga : EndpointConfigurationBuilder
+        {
+            public ReceiverWithSaga()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageToSaga>
+            {
+
+                public void Handle(StartSaga1 message)
+                {
+                }
+
+                public void Handle(MessageToSaga message)
+                {
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                }
+            }
+
+            public class SagaNotFound : IHandleSagaNotFound
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(object message)
+                {
+                    Bus.Reply(new Reply());
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MessageToSaga : ICommand
+        {
+        }
+
+        [Serializable]
+        public class Reply : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_a_saga_is_started_by_an_event_published_by_another_saga.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_a_saga_is_started_by_an_event_published_by_another_saga.cs
@@ -1,0 +1,217 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using PubSub;
+    using Saga;
+    using ScenarioDescriptors;
+
+    //Repro for #1323
+    public class When_a_saga_is_started_by_an_event_published_by_another_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_start_the_saga_and_request_a_timeout()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SagaThatPublishesAnEvent>(b =>
+                                                            b.Given(
+                                                                (bus, context) =>
+                                                                Subscriptions.OnEndpointSubscribed(s =>
+                                                                    {
+                                                                        if (s.SubscriberReturnAddress.Queue.Contains("SagaThatIsStartedByTheEvent"))
+                                                                        {
+                                                                            context.IsEventSubscriptionReceived = true;
+                                                                        }
+                                                                    }))
+                                                             .When(c => c.IsEventSubscriptionReceived,
+                                                                   bus =>
+                                                                   bus.SendLocal(new StartSaga {DataId = Guid.NewGuid()}))
+                )
+                    .WithEndpoint<SagaThatIsStartedByTheEvent>(
+                        b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<SomethingHappenedEvent>();
+
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                context.IsEventSubscriptionReceived = true;
+                        }))
+
+                    .Done(c => c.DidSaga1Complete && c.DidSaga2Complete)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSaga1Complete && c.DidSaga2Complete))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSaga1Complete { get; set; }
+            public bool DidSaga2Complete { get; set; }
+            public bool IsEventSubscriptionReceived { get; set; }
+        }
+
+
+        [Test]
+        [Ignore("Not stable")]
+        public void Should_start_the_saga_when_set_up_to_start_for_the_base_event()
+        {
+            Scenario.Define<SagaContext>()
+                 .WithEndpoint<SagaThatPublishesAnEvent>(b =>
+                                                         b.Given(
+                                                             (bus, context) =>
+                                                             Subscriptions.OnEndpointSubscribed(s =>
+                                                             {
+                                                                 if (s.SubscriberReturnAddress.Queue.Contains("SagaThatIsStartedByABaseEvent"))
+                                                                 {
+                                                                     context.IsEventSubscriptionReceived = true;
+                                                                 }
+                                                             }))
+                                                          .When(c => c.IsEventSubscriptionReceived,
+                                                                bus =>
+                                                                bus.Publish<SomethingHappenedEvent>(m=> { m.DataId = Guid.NewGuid(); }))
+             )
+                 .WithEndpoint<SagaThatIsStartedByABaseEvent>(
+                     b => b.Given((bus, context) =>
+                     {
+                         bus.Subscribe<BaseEvent>();
+
+                          if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                              context.IsEventSubscriptionReceived = true;
+                     }))
+                 .Done(c => c.DidSagaComplete)
+                 .Repeat(r => r.For(Transports.Default))
+                 .Should(c => Assert.True(c.DidSagaComplete))
+                 .Run(TimeSpan.FromMinutes(3));
+        }
+
+        public class SagaContext : ScenarioContext
+        {
+            public bool IsEventSubscriptionReceived { get; set; }
+            public bool DidSagaComplete { get; set; }
+        }
+
+        public class SagaThatPublishesAnEvent : EndpointConfigurationBuilder
+        {
+            public SagaThatPublishesAnEvent()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>());
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga>, IHandleTimeouts<Saga1.Timeout1>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    Data.DataId = message.DataId;
+
+                    //Publish the event, which will start the second saga
+                    Bus.Publish<SomethingHappenedEvent>(m => { m.DataId = message.DataId; });
+
+                    //Request a timeout
+                    RequestTimeout<Timeout1>(TimeSpan.FromSeconds(5));
+                }
+
+                public void Timeout(Timeout1 state)
+                {
+                    MarkAsComplete();
+                    Context.DidSaga1Complete = true;
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+                public class Timeout1
+                {
+                }
+            }
+        }
+
+        public class SagaThatIsStartedByTheEvent : EndpointConfigurationBuilder
+        {
+            public SagaThatIsStartedByTheEvent()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<SomethingHappenedEvent>(typeof(SagaThatPublishesAnEvent));
+
+            }
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<SomethingHappenedEvent>, IHandleTimeouts<Saga2.Saga2Timeout>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(SomethingHappenedEvent message)
+                {
+                    Data.DataId = message.DataId;
+
+                    //Request a timeout
+                    RequestTimeout<Saga2Timeout>(TimeSpan.FromSeconds(5));
+                }
+
+                public void Timeout(Saga2Timeout state)
+                {
+                    MarkAsComplete();
+                    Context.DidSaga2Complete = true;
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+                public class Saga2Timeout
+                {
+                }
+            }
+        }
+
+        public class SagaThatIsStartedByABaseEvent : EndpointConfigurationBuilder
+        {
+            public SagaThatIsStartedByABaseEvent()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<AutoSubscribe>())
+                    .AddMapping<BaseEvent>(typeof(SagaThatPublishesAnEvent));
+            }
+
+            public class SagaStartedByBaseEvent : Saga<SagaStartedByBaseEvent.SagaData>, IAmStartedByMessages<BaseEvent>
+            {
+                public SagaContext Context { get; set; }
+
+                public void Handle(BaseEvent message)
+                {
+                    Data.DataId = message.DataId;
+                    MarkAsComplete();
+                    Context.DidSagaComplete = true;
+                }
+
+                public class SagaData : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public interface SomethingHappenedEvent : BaseEvent
+        {
+          
+        }
+
+        public interface BaseEvent : IEvent
+        {
+            Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
@@ -1,0 +1,97 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    //repro for issue: https://github.com/NServiceBus/NServiceBus/issues/1020
+    public class When_a_saga_message_goes_through_the_slr : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_invoke_the_correct_handle_methods_on_the_saga()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid() })))
+                    .Done(c => c.SecondMessageProcessed)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SecondMessageProcessed { get; set; }
+
+
+            public int NumberOfTimesInvoked { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AllowExceptions();
+            }
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>,IHandleMessages<SecondSagaMessage>
+            {
+                public Context Context { get; set; }
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+
+                    Bus.SendLocal(new SecondSagaMessage
+                        {
+                            SomeId = Data.SomeId
+                        });
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSagaMessage>(m=>m.SomeId)
+                        .ToSaga(s=>s.SomeId);
+                    ConfigureMapping<SecondSagaMessage>(m => m.SomeId)
+                      .ToSaga(s => s.SomeId);
+                }
+
+                public void Handle(SecondSagaMessage message)
+                {
+                    Context.NumberOfTimesInvoked++;
+                    var shouldFail = Context.NumberOfTimesInvoked < 2; //1 FLR and 1 SLR
+
+                    if(shouldFail)
+                        throw new Exception("Simulated exception");
+
+                    Context.SecondMessageProcessed = true;
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+        public class SecondSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+        
+        public class SomeTimeout
+        {
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
@@ -1,0 +1,108 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    // Repro for issue  https://github.com/NServiceBus/NServiceBus/issues/1277 to test the fix
+    // making sure that the saga correlation still works.
+    public class When_an_endpoint_replies_to_a_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_correlate_all_saga_messages_properly()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointThatHostsASaga>(b => b.Given(bus => bus.SendLocal(new StartSaga { DataId = Guid.NewGuid() })))
+                    .WithEndpoint<EndpointThatHandlesAMessageFromSagaAndReplies>()
+                    .Done(c => c.DidSagaReplyMessageGetCorrelated)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSagaReplyMessageGetCorrelated))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSagaReplyMessageGetCorrelated { get; set; }
+        }
+
+        public class EndpointThatHandlesAMessageFromSagaAndReplies : EndpointConfigurationBuilder
+        {
+            public EndpointThatHandlesAMessageFromSagaAndReplies()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class DoSomethingHandler : IHandleMessages<DoSomething>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(DoSomething message)
+                {
+                    Console.WriteLine("Received DoSomething command for DataId:{0} ... and responding with a reply", message.DataId);
+                    Bus.Reply(new DoSomethingResponse { DataId = message.DataId });
+                }
+            }
+        }
+
+        public class EndpointThatHostsASaga : EndpointConfigurationBuilder
+        {
+            public EndpointThatHostsASaga()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<DoSomething>(typeof (EndpointThatHandlesAMessageFromSagaAndReplies));
+
+            }
+
+            public class Saga2 : Saga<Saga2.MySaga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<DoSomethingResponse>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    var dataId = Guid.NewGuid();
+                    Console.Out.WriteLine("Saga2 sending DoSomething for DataId: {0}", dataId);
+                    Data.DataId = dataId;
+                    Bus.Send(new DoSomething { DataId = dataId });
+                }
+
+                public void Handle(DoSomethingResponse message)
+                {
+                    Context.DidSagaReplyMessageGetCorrelated = message.DataId == Data.DataId;
+                    Console.Out.WriteLine("Saga received DoSomethingResponse for DataId: {0} and MarkAsComplete", message.DataId);
+                    MarkAsComplete();
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySaga2Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+            }
+        }
+        
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class DoSomething : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class DoSomethingResponse : IMessage
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
@@ -1,0 +1,104 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_doing_request_response_between_sagas : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_autocorrelate_the_response_back_to_the_requesting_saga()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new InitiateRequestingSaga { DataId = Guid.NewGuid() })))
+                    .Done(c => c.DidRequestingSagaGetTheResponse)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidRequestingSagaGetTheResponse))
+                    .Run(TimeSpan.FromSeconds(20));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidRequestingSagaGetTheResponse { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class RequestingSaga : Saga<RequestingSaga.RequestingSagaData>, 
+                IAmStartedByMessages<InitiateRequestingSaga>, 
+                IHandleMessages<ResponseFromOtherSaga>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(InitiateRequestingSaga message)
+                {
+                    Data.DataId = message.DataId;
+                    Bus.SendLocal(new RequestToRespondingSaga { DataId = message.DataId });
+                }
+
+                public void Handle(ResponseFromOtherSaga message)
+                {
+                    Context.DidRequestingSagaGetTheResponse = true;
+                    MarkAsComplete();
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<InitiateRequestingSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+                public class RequestingSagaData : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+            }
+
+            public class RespondingSaga : Saga<RespondingSaga.RespondingSagaData>, 
+                IAmStartedByMessages<RequestToRespondingSaga>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(RequestToRespondingSaga message)
+                {
+                    Bus.Reply(new ResponseFromOtherSaga { DataId = message.DataId });
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                }
+
+                public class RespondingSagaData : ContainSagaData
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class InitiateRequestingSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        [Serializable]
+        public class RequestToRespondingSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        [Serializable]
+        public class ResponseFromOtherSaga : IMessage
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
@@ -1,0 +1,95 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Saga;
+    using NUnit.Framework;
+
+    public class When_message_has_a_saga_id : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_start_a_new_saga_if_not_found()
+        {
+            var context = Scenario.Define<Context>()
+                .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                {
+                    var message = new MessageWithSagaId();
+
+                    bus.SetMessageHeader(message, Headers.SagaId, Guid.NewGuid().ToString());
+                    bus.SetMessageHeader(message, Headers.SagaType, typeof(MySaga).AssemblyQualifiedName);
+
+                    bus.SendLocal(message);
+                }))
+                .Done(c => c.NotFoundHandlerCalled && c.OtherSagaStarted)
+                .Run(TimeSpan.FromSeconds(15));
+
+            Assert.True(context.NotFoundHandlerCalled);
+            Assert.True(context.OtherSagaStarted);
+            Assert.False(context.MessageHandlerCalled);
+            Assert.False(context.TimeoutHandlerCalled);
+        }
+
+        class MySaga : Saga<MySaga.SagaData>, IAmStartedByMessages<MessageWithSagaId>,
+            IHandleTimeouts<MessageWithSagaId>,
+            IHandleSagaNotFound
+        {
+            public Context Context { get; set; }
+
+            public class SagaData : ContainSagaData
+            {
+            }
+
+            public void Handle(MessageWithSagaId message)
+            {
+                Context.MessageHandlerCalled = true;
+            }
+
+            public void Handle(object message)
+            {
+                Context.NotFoundHandlerCalled = true;
+            }
+
+            public void Timeout(MessageWithSagaId state)
+            {
+                Context.TimeoutHandlerCalled = true;
+            }
+        }
+
+        class MyOtherSaga : Saga<MyOtherSaga.SagaData>, IAmStartedByMessages<MessageWithSagaId>
+        {
+            public Context Context { get; set; }
+
+            public void Handle(MessageWithSagaId message)
+            {
+                Context.OtherSagaStarted = true;
+            }
+
+            public class SagaData : ContainSagaData
+            {
+            }
+
+        }
+
+
+        class Context : ScenarioContext
+        {
+            public bool NotFoundHandlerCalled { get; set; }
+            public bool MessageHandlerCalled { get; set; }
+            public bool TimeoutHandlerCalled { get; set; }
+            public bool OtherSagaStarted { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class MessageWithSagaId : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_is_mapped_to_an_existing_saga_instance.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_is_mapped_to_an_existing_saga_instance.cs
@@ -1,0 +1,89 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_that_is_mapped_to_an_existing_saga_instance : NServiceBusAcceptanceTest
+    {
+        static Guid IdThatSagaIsCorrelatedOn = Guid.NewGuid();
+
+        [Test]
+        public void Should_hydrate_and_invoke_the_existing_instance()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                        {
+                            bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn });
+                            bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn, SecondMessage = true });                                    
+                        }))
+                    .Done(c => c.SecondMessageReceived)
+                    .Repeat(r => r.For(SagaPersisters.Default))
+                    .Should(c => Assert.AreEqual(c.FirstSagaInstance, c.SecondSagaInstance, "The same saga instance should be invoked invoked for both messages"))
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SecondMessageReceived { get; set; }
+
+            public Guid FirstSagaInstance { get; set; }
+            public Guid SecondSagaInstance { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c=>Configure.Transactions.Advanced(a => a.DoNotWrapHandlersExecutionInATransactionScope()));
+            }
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>
+            {
+                public Context Context { get; set; }
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+
+                    if (message.SecondMessage)
+                    {
+                        Context.SecondSagaInstance = Data.Id;
+                        Context.SecondMessageReceived = true;
+                    }
+                    else
+                    {
+                        Context.FirstSagaInstance = Data.Id;
+                    }
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSagaMessage>(m=>m.SomeId)
+                        .ToSaga(s=>s.SomeId);
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+
+                [Unique]
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+
+            public bool SecondMessage { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_should_complete_saga.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_should_complete_saga.cs
@@ -1,0 +1,141 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_that_completes_the_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_hydrate_and_complete_the_existing_instance()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<SagaEndpoint>(b =>
+                        {
+                            b.Given((bus, context) => bus.SendLocal(new StartSagaMessage {SomeId = context.Id}));
+                            b.When(context => context.StartSagaMessageReceived, (bus, context) => bus.SendLocal(new CompleteSagaMessage { SomeId = context.Id }));
+                        })
+                    .Done(c => c.SagaCompleted)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.IsNull(c.UnhandledException))
+
+                    .Run();
+        }
+
+        [Test]
+        public void Should_ignore_messages_afterwards()
+        {
+            Scenario.Define(() => new Context {Id = Guid.NewGuid()})
+                      .WithEndpoint<SagaEndpoint>(b =>
+                      {
+                          b.Given((bus, context) => bus.SendLocal(new StartSagaMessage { SomeId = context.Id }));
+                          b.When(context => context.StartSagaMessageReceived, (bus, context) => bus.SendLocal(new CompleteSagaMessage { SomeId = context.Id }));
+                          b.When(context => context.SagaCompleted, (bus, context) => bus.SendLocal(new AnotherMessage { SomeId = context.Id }));
+                      })
+                    .Done(c => c.AnotherMessageReceived)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c =>
+                        {
+                            Assert.IsNull(c.UnhandledException);
+                            Assert.False(c.SagaReceivedAnotherMessage,"AnotherMessage should not be delivered to the saga after completion");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Exception UnhandledException { get; set; }
+            public Guid Id { get; set; }
+
+            public bool StartSagaMessageReceived { get; set; }
+
+            public bool SagaCompleted { get; set; }
+
+            public bool AnotherMessageReceived { get; set; }
+            public bool SagaReceivedAnotherMessage { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    c => c.RavenSagaPersister().UnicastBus().LoadMessageHandlers<First<TestSaga>>());
+            }
+
+          
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>, IHandleMessages<CompleteSagaMessage>, IHandleMessages<AnotherMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+
+                    Context.StartSagaMessageReceived = true;
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSagaMessage>(m=>m.SomeId)
+                        .ToSaga(s=>s.SomeId);
+                    ConfigureMapping<CompleteSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                    ConfigureMapping<AnotherMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                }
+
+                public void Handle(CompleteSagaMessage message)
+                {
+                    MarkAsComplete();
+                    Context.SagaCompleted = true;
+                }
+
+                public void Handle(AnotherMessage message)
+                {
+                    Context.SagaReceivedAnotherMessage = true;
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+                [Unique]
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        public class CompletionHandler : IHandleMessages<AnotherMessage>
+        {
+            public Context Context { get; set; }
+            public void Handle(AnotherMessage message)
+            {
+                Context.AnotherMessageReceived = true;
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        [Serializable]
+        public class CompleteSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        [Serializable]
+        public class AnotherMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_should_start_a_saga.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_receiving_a_message_that_should_start_a_saga.cs
@@ -1,0 +1,101 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_that_should_start_a_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_start_the_saga_and_call_all_messagehandlers_for_the_given_message()
+        {
+            Scenario.Define<SagaEndpointContext>()
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage())))
+                    .Done(context => context.InterceptingHandlerCalled && context.SagaStarted)
+                    .Repeat(r => r.For<AllBuilders>())
+                    .Should(c =>
+                    {
+                        Assert.True(c.InterceptingHandlerCalled, "The message handler should be called");
+                        Assert.True(c.SagaStarted, "The saga should have been started");
+                    })
+                    .Run();
+        }
+
+
+        [Test]
+        public void Should_not_start_saga_if_a_interception_handler_has_been_invoked()
+        {
+            Scenario.Define(() => new SagaEndpointContext{InterceptSaga = true})
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage())))
+                   .Done(context => context.InterceptingHandlerCalled)
+                   .Repeat(r => r.For<AllBuilders>())
+                   .Should(c =>
+                        {
+                            Assert.True(c.InterceptingHandlerCalled, "The intercepting handler should be called");
+                            Assert.False(c.SagaStarted, "The saga should not have been started since the intercepting handler stops the pipeline");
+                        })
+                    .Run();
+        }
+
+
+        public class SagaEndpointContext : ScenarioContext
+        {
+            public bool InterceptingHandlerCalled { get; set; }
+
+            public bool SagaStarted { get; set; }
+
+            public bool InterceptSaga { get; set; }
+        }
+
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>c.UnicastBus().LoadMessageHandlers<First<InterceptingHandler>>());
+            }
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>
+            {
+                public SagaEndpointContext Context { get; set; }
+                public void Handle(StartSagaMessage message)
+                {
+                    Context.SagaStarted = true;
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+            }
+
+            public class InterceptingHandler : IHandleMessages<StartSagaMessage>
+            {
+                public SagaEndpointContext Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                    Context.InterceptingHandlerCalled = true;
+
+                    if(Context.InterceptSaga)
+                        Bus.DoNotContinueDispatchingCurrentMessageToHandlers();
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+        }
+
+
+    }
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
@@ -1,0 +1,105 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_sending_from_a_saga_handle : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_match_different_saga()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new StartSaga1 { DataId = Guid.NewGuid() })))
+                    .Done(c => c.DidSaga2ReceiveMessage)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSaga2ReceiveMessage))
+                    .Run(TimeSpan.FromSeconds(20));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSaga2ReceiveMessage { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageSaga1WillHandle>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga1 message)
+                {
+                    var dataId = Guid.NewGuid();
+                    Data.DataId = dataId;
+                    Bus.SendLocal(new MessageSaga1WillHandle
+                             {
+                                 DataId = dataId
+                             });
+                }
+
+                public void Handle(MessageSaga1WillHandle message)
+                {
+                    Bus.SendLocal(new StartSaga2());
+                    MarkAsComplete();
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<MessageSaga1WillHandle>(m => m.DataId).ToSaga(s => s.DataId);
+                    ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+            }
+
+            public class Saga1Data : ContainSagaData
+            {
+                [Unique]
+                public virtual Guid DataId { get; set; }
+            }
+
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartSaga2>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga2 message)
+                {
+                    Context.DidSaga2ReceiveMessage = true;
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                }
+            }
+
+        }
+
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+
+        [Serializable]
+        public class StartSaga2 : ICommand
+        {
+        }
+        public class MessageSaga1WillHandle : IMessage
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
@@ -1,0 +1,88 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_sending_from_a_saga_timeout : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_match_different_saga()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new StartSaga1())))
+                    .Done(c => c.DidSaga2ReceiveMessage)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSaga2ReceiveMessage))
+                    .Run(TimeSpan.FromSeconds(20));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSaga2ReceiveMessage { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga1 message)
+                {
+                    RequestTimeout(TimeSpan.FromSeconds(1), new Saga1Timeout());
+                }
+
+                public void Timeout(Saga1Timeout state)
+                {
+                    Bus.SendLocal(new StartSaga2());
+                    MarkAsComplete();
+                }
+                public class Saga1Data : ContainSagaData
+                {
+                }
+            }
+
+
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartSaga2>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga2 message)
+                {
+                    Context.DidSaga2ReceiveMessage = true;
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                }
+            }
+
+        }
+
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+        }
+
+        [Serializable]
+        public class StartSaga2 : ICommand
+        {
+        }
+
+        public class Saga1Timeout : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
@@ -1,0 +1,161 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using PubSub;
+    using Saga;
+    using ScenarioDescriptors;
+
+    // Repro for issue  https://github.com/NServiceBus/NServiceBus/issues/1277
+    public class When_two_sagas_subscribe_to_the_same_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_invoke_all_handlers_on_all_sagas()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointThatHostsTwoSagas>(b => 
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                        {
+                            if (s.SubscriberReturnAddress.Queue.Contains("Saga1"))
+                            {
+                                context.Subscribed = true;
+                            }
+                        }))
+                        .When(c => true, bus => bus.SendLocal(new StartSaga2
+                        {
+                            DataId = Guid.NewGuid()
+                        }))
+                     )
+                    .WithEndpoint<EndpointThatHandlesAMessageAndPublishesEvent>()
+                    .Done(c => c.DidSaga1EventHandlerGetInvoked && c.DidSaga2EventHandlerGetInvoked)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSaga1EventHandlerGetInvoked && c.DidSaga2EventHandlerGetInvoked))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscribed { get; set; }
+            public bool DidSaga1EventHandlerGetInvoked { get; set; }
+            public bool DidSaga2EventHandlerGetInvoked { get; set; }
+        }
+
+        public class EndpointThatHandlesAMessageAndPublishesEvent : EndpointConfigurationBuilder
+        {
+            public EndpointThatHandlesAMessageAndPublishesEvent()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class OpenGroupCommandHandler : IHandleMessages<OpenGroupCommand>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(OpenGroupCommand message)
+                {
+                    Console.WriteLine("Received OpenGroupCommand for DataId:{0} ... and publishing GroupPendingEvent", message.DataId);
+                    Bus.Publish(new GroupPendingEvent { DataId = message.DataId });
+                }
+            }
+        }
+
+        public class EndpointThatHostsTwoSagas : EndpointConfigurationBuilder
+        {
+            public EndpointThatHostsTwoSagas()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<OpenGroupCommand>(typeof(EndpointThatHandlesAMessageAndPublishesEvent))
+                    .AddMapping<GroupPendingEvent>(typeof(EndpointThatHandlesAMessageAndPublishesEvent));
+            }
+
+            public class Saga1 : Saga<Saga1.MySaga1Data>, IAmStartedByMessages<GroupPendingEvent>, IHandleMessages<CompleteSaga1Now>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(GroupPendingEvent message)
+                {
+                    Data.DataId = message.DataId;
+                    Console.Out.WriteLine("Saga1 received GroupPendingEvent for DataId: {0}", message.DataId);
+                    Context.DidSaga1EventHandlerGetInvoked = true;
+                    Bus.SendLocal(new CompleteSaga1Now { DataId = message.DataId });
+                }
+
+                public void Handle(CompleteSaga1Now message)
+                {
+                    Console.Out.WriteLine("Saga1 received CompleteSaga1Now for DataId:{0} and MarkAsComplete", message.DataId);
+
+                    MarkAsComplete();
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<GroupPendingEvent>(m => m.DataId).ToSaga(s => s.DataId);
+                    ConfigureMapping<CompleteSaga1Now>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySaga1Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual  Guid DataId { get; set; }
+                }
+            }
+
+            public class Saga2 : Saga<Saga2.MySaga2Data>, IAmStartedByMessages<StartSaga2>, IHandleMessages<GroupPendingEvent>
+            {
+                public Context Context { get; set; }
+         
+                public void Handle(StartSaga2 message)
+                {
+                    var dataId = Guid.NewGuid();
+                    Console.Out.WriteLine("Saga2 sending OpenGroupCommand for DataId: {0}", dataId);
+                    Data.DataId = dataId;
+                    Bus.Send(new OpenGroupCommand { DataId = dataId });
+                }
+
+                public void Handle(GroupPendingEvent message)
+                {
+                    Context.DidSaga2EventHandlerGetInvoked = true;
+                    Console.Out.WriteLine("Saga2 received GroupPendingEvent for DataId: {0} and MarkAsComplete", message.DataId);
+                    MarkAsComplete();
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
+                    ConfigureMapping<GroupPendingEvent>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySaga2Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual  Guid DataId { get; set; }
+                }
+            }
+        }
+
+        [Serializable]
+        public class GroupPendingEvent : IEvent
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class OpenGroupCommand : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        [Serializable]
+        public class StartSaga2 : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class CompleteSaga1Now : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using PubSub;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_using_a_received_message_for_timeout : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Timeout_should_be_received_after_expiration()
+        {
+            Scenario.Define(() => new Context {Id = Guid.NewGuid()})
+                    .WithEndpoint<SagaEndpoint>(b =>
+                    {
+                        b.Given((bus, context) =>
+                        {
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                            {
+                                bus.SendLocal(new StartSagaMessage { SomeId = context.Id });
+                            }
+                            else
+                            {
+                                Subscriptions.OnEndpointSubscribed(s => bus.SendLocal(new StartSagaMessage { SomeId = context.Id }));
+                            }
+
+                        });
+
+                        b.When(context => context.StartSagaMessageReceived,
+                            (bus, context) => bus.Publish(new SomeEvent { SomeId = context.Id }));
+
+                    })
+                    .Done(c => c.TimeoutReceived)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public bool StartSagaMessageReceived { get; set; }
+
+            public bool SomeEventReceived { get; set; }
+
+            public bool TimeoutReceived { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.RavenSagaPersister()
+                                                   .UnicastBus())
+                    .AddMapping<SomeEvent>(typeof (SagaEndpoint));
+            }
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>,
+                                    IHandleMessages<SomeEvent>, IHandleTimeouts<SomeEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+                    Context.StartSagaMessageReceived = true;
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                    ConfigureMapping<SomeEvent>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                }
+
+                public void Handle(SomeEvent message)
+                {
+                    RequestTimeout(TimeSpan.FromMilliseconds(100), message);
+                    Context.SomeEventReceived = true;
+                }
+
+                public void Timeout(SomeEvent message)
+                {
+                    Context.TimeoutReceived = true;
+                    MarkAsComplete();
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+
+                [Unique]
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        [Serializable]
+        public class SomeEvent : IEvent
+        {
+            public Guid SomeId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    // Repro for #SB-191
+    public class When_using_contain_saga_data : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_handle_timeouts_properly()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointThatHostsASaga>(
+                        b => b.Given(bus => bus.SendLocal(new StartSaga {DataId = Guid.NewGuid()})))
+                    .Done(c => c.DidAllSagaInstancesReceiveTimeouts)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidAllSagaInstancesReceiveTimeouts))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidAllSagaInstancesReceiveTimeouts { get; set; }
+        }
+
+        public class EndpointThatHostsASaga : EndpointConfigurationBuilder
+        {
+            public EndpointThatHostsASaga()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MySaga : Saga<MySaga.MySagaData>,
+                                                             IAmStartedByMessages<StartSaga>,
+                                                             IHandleTimeouts<MySaga.TimeHasPassed>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    Data.DataId = message.DataId;
+
+                    RequestTimeout(TimeSpan.FromSeconds(5), new TimeHasPassed());
+                }
+
+                public void Timeout(TimeHasPassed state)
+                {
+                    MarkAsComplete();
+
+                    Context.DidAllSagaInstancesReceiveTimeouts = true;
+                }
+
+                public override void ConfigureHowToFindSaga()
+                {
+                    ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySagaData : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+                public class TimeHasPassed
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllBuilders.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllBuilders.cs
@@ -1,0 +1,17 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using AcceptanceTesting.Support;
+
+    public class AllBuilders : ScenarioDescriptor
+    {
+        public AllBuilders()
+        {
+            Add(Builders.Autofac);
+            Add(Builders.Windsor);
+            Add(Builders.Ninject);
+            Add(Builders.Spring);
+            Add(Builders.StructureMap);
+            Add(Builders.Unity);
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllSerializers.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllSerializers.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using AcceptanceTesting.Support;
+
+    public class AllSerializers : ScenarioDescriptor
+    {
+        public AllSerializers()
+        {
+            Add(Serializers.Bson);
+            Add(Serializers.Json);
+            Add(Serializers.Xml);
+            Add(Serializers.Binary);
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllSubscriptionStorages.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllSubscriptionStorages.cs
@@ -1,0 +1,14 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using AcceptanceTesting.Support;
+
+    public class AllSubscriptionStorages : ScenarioDescriptor
+    {
+        public AllSubscriptionStorages()
+        {
+            Add(SubscriptionStorages.InMemory);
+            Add(SubscriptionStorages.Raven);
+            Add(SubscriptionStorages.Msmq);
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllTransports.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllTransports.cs
@@ -1,0 +1,121 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using AcceptanceTesting.Support;
+    using Hosting.Helpers;
+    using NServiceBus.Transports;
+
+    public class AllTransports : ScenarioDescriptor
+    {
+        public AllTransports()
+        {
+            AddRange(ActiveTransports);
+        }
+
+        static IEnumerable<RunDescriptor> ActiveTransports
+        {
+            get
+            {
+                if (activeTransports == null)
+                {
+                    //temporary fix until we can get rid of the "AllTransports" all together
+                    activeTransports = new List<RunDescriptor>
+                    {
+                        Transports.Default
+                    }; 
+                }
+
+                return activeTransports;
+            }
+        }
+
+        static ICollection<RunDescriptor> activeTransports;
+    }
+
+    public class AllDtcTransports : AllTransports
+    {
+        public AllDtcTransports()
+        {
+            AllTransportsFilter.Run(t => t.HasSupportForDistributedTransactions.HasValue
+                                         && !t.HasSupportForDistributedTransactions.Value, Remove);
+
+            // todo set HasSupportForDistributedTransactions to false on Rabbit MQ
+            AllTransportsFilter.Run(t => t.GetType().Name.Contains("RabbitMQ"), Remove);
+        }
+    }
+
+    public class AllBrokerTransports : AllTransports
+    {
+        public AllBrokerTransports()
+        {
+            AllTransportsFilter.Run(t => !t.HasNativePubSubSupport, Remove);
+        }
+    }
+
+    public class AllTransportsWithCentralizedPubSubSupport : AllTransports
+    {
+        public AllTransportsWithCentralizedPubSubSupport()
+        {
+            AllTransportsFilter.Run(t => !t.HasSupportForCentralizedPubSub, Remove);
+        }
+    }
+
+    public class AllTransportsWithMessageDrivenPubSub : AllTransports
+    {
+        public AllTransportsWithMessageDrivenPubSub()
+        {
+            AllTransportsFilter.Run(t => t.HasNativePubSubSupport, Remove);
+        }
+    }
+
+    public class TypeScanner
+    {
+
+        public static IEnumerable<Type> GetAllTypesAssignableTo<T>()
+        {
+            return AvailableAssemblies.SelectMany(a => a.GetTypes())
+                                      .Where(t => typeof (T).IsAssignableFrom(t) && t != typeof(T))
+                                      .ToList();
+        }
+
+        static IEnumerable<Assembly> AvailableAssemblies
+        {
+            get
+            {
+                if (assemblies == null)
+                {
+                    var result = new AssemblyScanner().GetScannableAssemblies();
+
+                    assemblies = result.Assemblies;
+                }
+                    
+                return assemblies;
+            }
+        }
+
+        static List<Assembly> assemblies;
+    }
+
+    public static class AllTransportsFilter
+    {
+        public static void Run(Func<TransportDefinition, bool> condition, Func<RunDescriptor, bool> remove)
+        {
+            foreach (var rundescriptor in Transports.AllAvailable)
+            {
+                var transportAssemblyQualifiedName = rundescriptor.Settings["Transport"];
+                var type = Type.GetType(transportAssemblyQualifiedName);
+                if (type != null)
+                {
+                    var transport = Activator.CreateInstance(type) as TransportDefinition;
+                    if (condition(transport))
+                    {
+                        remove(rundescriptor);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Builders.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Builders.cs
@@ -1,0 +1,61 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using ObjectBuilder.Common;
+
+    public static class Builders
+    {
+        static IList<RunDescriptor> availableTransports;
+
+        public static IEnumerable<RunDescriptor> AllAvailable
+        {
+            get { return availableTransports ?? (availableTransports = GetAllAvailable().ToList()); }
+        }
+
+        static IEnumerable<RunDescriptor> GetAllAvailable()
+        {
+            var builders = TypeScanner.GetAllTypesAssignableTo<IContainer>()
+                .Where(t => !t.Assembly.FullName.StartsWith("NServiceBus.Core") && //exclude the default builder
+                            t.Name.EndsWith("ObjectBuilder") ) //exclude the ninject child container 
+                .ToList();
+
+            return from builder in builders let name = builder.Name.Replace("ObjectBuilder", "") select (new RunDescriptor
+            {
+                Key = name,
+                Settings = new Dictionary<string, string> { { "Builder", builder.AssemblyQualifiedName } }
+            });
+        }
+
+        public static RunDescriptor Autofac
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Autofac"); }
+        }
+
+        public static RunDescriptor Ninject
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Ninject"); }
+        }
+
+        public static RunDescriptor StructureMap
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "StructureMap"); }
+        }
+
+        public static RunDescriptor Windsor
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Windsor"); }
+        }
+
+        public static RunDescriptor Spring
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Spring"); }
+        }
+
+        public static RunDescriptor Unity
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Unity"); }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SagaPersisters.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SagaPersisters.cs
@@ -1,0 +1,61 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using Persistence.InMemory.SagaPersister;
+    using Persistence.Raven.SagaPersister;
+    using Saga;
+
+    public class SagaPersisters : ScenarioDescriptor
+    {
+        public SagaPersisters()
+        {
+            var persisters = AvailablePersisters;
+
+            foreach (var persister in persisters)
+            {
+                Add(new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string> { { "SagaPersister", persister.AssemblyQualifiedName } }
+                });
+            }
+        }
+
+        static List<Type> AvailablePersisters
+        {
+            get
+            {
+                var persisters = TypeScanner.GetAllTypesAssignableTo<ISagaPersister>()
+                    .Where(t => !t.IsInterface)
+                    .ToList();
+                return persisters;
+            }
+        }
+
+        public static RunDescriptor Default
+        {
+            get
+            {
+                var persisters = AvailablePersisters;
+                var persister = persisters.FirstOrDefault(p => p != typeof(InMemorySagaPersister) && p != typeof(RavenSagaPersister));
+
+                if (persister == null)
+                {
+                    persister = typeof(InMemorySagaPersister);
+                }
+
+                return new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string>
+                    {
+                        {"SagaPersister", persister.AssemblyQualifiedName}
+                    }
+                };
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Serializers.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Serializers.cs
@@ -1,0 +1,59 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System.Collections.Generic;
+    using AcceptanceTesting.Support;
+    using NServiceBus.Serializers.Binary;
+    using NServiceBus.Serializers.Json;
+    using NServiceBus.Serializers.XML;
+
+    public static class Serializers
+    {
+        public static readonly RunDescriptor Binary = new RunDescriptor
+            {
+                Key = "Binary",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (BinaryMessageSerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+        public static readonly RunDescriptor Bson = new RunDescriptor
+            {
+                Key = "Bson",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (BsonMessageSerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+        public static readonly RunDescriptor Xml = new RunDescriptor
+            {
+                Key = "Xml",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (XmlMessageSerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+        public static readonly RunDescriptor Json = new RunDescriptor
+            {
+                Key = "Json",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (JsonMessageSerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SubscriptionPersisters.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SubscriptionPersisters.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using Persistence.InMemory.SubscriptionStorage;
+    using Persistence.Msmq.SubscriptionStorage;
+    using Persistence.Raven.SubscriptionStorage;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
+    public class SubscriptionPersisters : ScenarioDescriptor
+    {
+        public SubscriptionPersisters()
+        {
+            var persisters = AvailablePersisters;
+
+            foreach (var persister in persisters)
+            {
+                Add(new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string> { { "SubscriptionStorage", persister.AssemblyQualifiedName } }
+                });
+            }
+        }
+
+        static List<Type> AvailablePersisters
+        {
+            get
+            {
+                var persisters = TypeScanner.GetAllTypesAssignableTo<ISubscriptionStorage>()
+                    .Where(t => !t.IsInterface)
+                    .ToList();
+                return persisters;
+            }
+        }
+
+        public static RunDescriptor Default
+        {
+            get
+            {
+                var persisters = AvailablePersisters;
+                var persister = persisters.FirstOrDefault(p => p != typeof(InMemorySubscriptionStorage) && p != typeof(RavenSubscriptionStorage) && p != typeof(MsmqSubscriptionStorage));
+
+                if (persister == null)
+                {
+                    persister = typeof(InMemorySubscriptionStorage);
+                }
+
+                return new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string>
+                    {
+                        {"SubscriptionStorage", persister.AssemblyQualifiedName}
+                    }
+                };
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SubscriptionStorages.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/SubscriptionStorages.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System.Collections.Generic;
+    using AcceptanceTesting.Support;
+    using Persistence.InMemory.SubscriptionStorage;
+    using Persistence.Msmq.SubscriptionStorage;
+    using Persistence.Raven.SubscriptionStorage;
+
+    public static class SubscriptionStorages
+    {
+        public static readonly RunDescriptor InMemory = new RunDescriptor
+            {
+                Key = "InMemorySubscriptionStorage",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "SubscriptionStorage",
+                                typeof (InMemorySubscriptionStorage).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+
+        public static readonly RunDescriptor Raven = new RunDescriptor
+            {
+                Key = "RavenSubscriptionStorage",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "SubscriptionStorage",
+                                typeof (RavenSubscriptionStorage).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+      
+        public static readonly RunDescriptor Msmq = new RunDescriptor
+            {
+                Key = "MsmqSubscriptionStorage",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "SubscriptionStorage",
+                                typeof (MsmqSubscriptionStorage).AssemblyQualifiedName
+                            }
+                        }
+            };
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/TimeoutPersisters.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/TimeoutPersisters.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using Persistence.InMemory.TimeoutPersister;
+    using Persistence.Raven.TimeoutPersister;
+    using Timeout.Core;
+
+    public class TimeoutPersisters : ScenarioDescriptor
+    {
+        public TimeoutPersisters()
+        {
+            var persisters = AvailablePersisters;
+
+            foreach (var persister in persisters)
+            {
+                Add(new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string> { { "TimeoutPersister", persister.AssemblyQualifiedName } }
+                });
+            }
+        }
+
+        static List<Type> AvailablePersisters
+        {
+            get
+            {
+                var persisters = TypeScanner.GetAllTypesAssignableTo<IPersistTimeouts>()
+                    .Where(t => !t.IsInterface)
+                    .ToList();
+                return persisters;
+            }
+        }
+
+        public static RunDescriptor Default
+        {
+            get
+            {
+                var persisters = AvailablePersisters;
+                var persister = persisters.FirstOrDefault(p => p != typeof(InMemoryTimeoutPersistence) && p != typeof(RavenTimeoutPersistence));
+
+                if (persister == null)
+                {
+                    persister = typeof(InMemoryTimeoutPersistence);
+                }
+
+                return new RunDescriptor
+                {
+                    Key = persister.Name,
+                    Settings = new Dictionary<string, string>
+                    {
+                        {"TimeoutPersister", persister.AssemblyQualifiedName}
+                    }
+                };
+            }
+        }
+    }
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Transports.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/ScenarioDescriptors/Transports.cs
@@ -1,0 +1,114 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using NServiceBus.Transports;
+
+    public static class Transports
+    {
+        public static IEnumerable<RunDescriptor> AllAvailable
+        {
+            get
+            {
+                if (availableTransports == null)
+                {
+                    availableTransports = GetAllAvailable().ToList();
+                }
+
+                return availableTransports;
+            }
+        }
+
+
+        public static RunDescriptor Default
+        {
+            get
+            {
+                var specificTransport = Environment.GetEnvironmentVariable("Transport.UseSpecific");
+
+                if (!string.IsNullOrEmpty(specificTransport))
+                    return AllAvailable.Single(r => r.Key == specificTransport);
+
+                var transportsOtherThanMsmq = AllAvailable.Where(t => t != Msmq);
+
+                if (transportsOtherThanMsmq.Count() == 1)
+                    return transportsOtherThanMsmq.First();
+
+                return Msmq;
+            }
+        }
+
+        public static RunDescriptor ActiveMQ
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "ActiveMQ"); }
+        }
+
+        public static RunDescriptor Msmq
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "Msmq"); }
+        }
+
+        public static RunDescriptor RabbitMQ
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "RabbitMQ"); }
+        }
+
+
+
+        public static RunDescriptor SqlServer
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "SqlServer"); }
+        }
+
+        static IEnumerable<RunDescriptor> GetAllAvailable()
+        {
+            var foundTransportDefinitions = TypeScanner.GetAllTypesAssignableTo<TransportDefinition>();
+
+            
+            foreach (var transportDefinitionType in foundTransportDefinitions)
+            {
+                var key = transportDefinitionType.Name;
+
+                var runDescriptor = new RunDescriptor
+                {
+                    Key = key,
+                    Settings =
+                        new Dictionary<string, string>
+                                {
+                                    {"Transport", transportDefinitionType.AssemblyQualifiedName}
+                                }
+                };
+
+                var connectionString = Environment.GetEnvironmentVariable(key + ".ConnectionString");
+
+                if (string.IsNullOrEmpty(connectionString) && DefaultConnectionStrings.ContainsKey(key))
+                    connectionString = DefaultConnectionStrings[key];
+
+
+                if (!string.IsNullOrEmpty(connectionString))
+                {
+                    runDescriptor.Settings.Add("Transport.ConnectionString", connectionString);
+                    yield return runDescriptor;
+                }
+                else
+                {
+                    Console.Out.WriteLine("No connection string found for transport: {0}, test will not be executed for this transport", key);
+                }
+            }
+        }
+
+        static IList<RunDescriptor> availableTransports;
+
+        static readonly Dictionary<string, string> DefaultConnectionStrings = new Dictionary<string, string>
+            {
+                {"RabbitMQ", "host=localhost"},
+                {"SqlServer", @"Server=localhost\sqlexpress;Database=nservicebus;Trusted_Connection=True;"},
+                {"ActiveMQ", @"ServerUrl=activemq:tcp://localhost:61616"},
+                {"Msmq", @"cacheSendConnection=false;journal=false;"}
+            };
+
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Scheduling/When_scheduling_a_recurring_task.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Scheduling/When_scheduling_a_recurring_task.cs
@@ -1,0 +1,55 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_scheduling_a_recurring_task : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_execute_the_task()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SchedulingEndpoint>()
+                    .Done(c => c.ScheduleActionInvoked)
+                    .Repeat(r => r.For(Transports.Default))
+                  .Run(TimeSpan.FromSeconds(60));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool ScheduleActionInvoked { get; set; }
+        }
+
+        public class SchedulingEndpoint : EndpointConfigurationBuilder
+        {
+            public SchedulingEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class SetupScheduledAction : IWantToRunWhenBusStartsAndStops
+            {
+                public void Start()
+                {
+                    Schedule.Every(TimeSpan.FromSeconds(5))
+                       .Action("MyTask", () =>
+                       {
+                           Console.Out.WriteLine("Task invoked");
+                           Configure.Instance.Builder.Build<Context>()
+                                    .ScheduleActionInvoked = true;
+                       });
+                }
+
+                public void Stop()
+                {
+
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/OutdatedTimeoutPersister.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/OutdatedTimeoutPersister.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.Timeout.Core;
+
+    class OutdatedTimeoutPersister : IPersistTimeouts
+    {
+        public List<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+        {
+            nextTimeToRunQuery = DateTime.Now.AddYears(42);
+            return Enumerable.Empty<Tuple<string, DateTime>>().ToList();
+        }
+
+        public void Add(TimeoutData timeout)
+        {
+        }
+
+        public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+        {
+            timeoutData = null;
+            return false;
+        }
+
+        public void RemoveTimeoutBy(Guid sagaId)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/UpdatedTimeoutPersister.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/UpdatedTimeoutPersister.cs
@@ -1,0 +1,40 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.Timeout.Core;
+
+    class UpdatedTimeoutPersister : IPersistTimeouts, IPersistTimeoutsV2
+    {
+        public List<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+        {
+            nextTimeToRunQuery = DateTime.Now.AddYears(42);
+            return Enumerable.Empty<Tuple<string, DateTime>>().ToList();
+        }
+
+        public void Add(TimeoutData timeout)
+        {
+        }
+
+        public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+        {
+            timeoutData = null;
+            return false;
+        }
+
+        public void RemoveTimeoutBy(Guid sagaId)
+        {
+        }
+
+        public TimeoutData Peek(string timeoutId)
+        {
+            return null;
+        }
+
+        public bool TryRemove(string timeoutId)
+        {
+            return true;
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_dispatched_timeout_already_removed_from_timeout_storage.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_dispatched_timeout_already_removed_from_timeout_storage.cs
@@ -1,0 +1,183 @@
+﻿//namespace NServiceBus.AcceptanceTests.Timeouts
+//{
+//    using System;
+//    using System.Collections.Generic;
+//    using System.Transactions;
+//    using NServiceBus.AcceptanceTesting;
+//    using NServiceBus.AcceptanceTests.EndpointTemplates;
+//    using NServiceBus.Config;
+//    using NServiceBus.Timeout.Core;
+//    using NUnit.Framework;
+//
+//    [CoreConcern]
+//    public class When_dispatched_timeout_already_removed_from_timeout_storage : NServiceBusAcceptanceTest
+//    {
+//        [Test]
+//        public void Should_rollback_and_not_deliver_timeout_when_using_dtc()
+//        {
+//            var context = new Context();
+//
+//            Scenario.Define(context)
+//                .WithEndpoint<TimeoutHandlingEndpoint>(b => b
+//                    .CustomConfig(configure => Configure.Transactions.Advanced(s => s.EnableDistributedTransactions()))
+//                    .Given(bus =>
+//                    {
+//                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+//                    }))
+//                .Done(c => c.AttemptedToRemoveTimeout || c.MessageReceived)
+//                .Run();
+//
+//            Assert.IsFalse(context.MessageReceived, "Message should not be delivered using dtc");
+//            Assert.AreEqual(2, context.NumberOfProcessingAttempts, "The rollback should cause a retry");
+//            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+//        }
+//
+//        [Test]
+//        public void Should_rollback_and_deliver_timeout_anyway_when_using_native_tx()
+//        {
+//            var context = new Context();
+//
+//            Scenario.Define(context)
+//                .WithEndpoint<TimeoutHandlingEndpoint>(b => b
+//                    .CustomConfig(configure => Configure.Transactions.Advanced(s => s.DisableDistributedTransactions()))
+//                    .Given(bus =>
+//                    {
+//                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+//                    }))
+//                .Done(c => c.AttemptedToRemoveTimeout && c.MessageReceived)
+//                .Run();
+//
+//            Assert.IsTrue(context.MessageReceived, "Message should be delivered although transaction has been aborted");
+//            Assert.AreEqual(2, context.NumberOfProcessingAttempts, "The rollback should cause a retry");
+//            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+//        }
+//
+//        [Test]
+//        public void Should_deliver_timeout_anyway_when_using_no_tx()
+//        {
+//            var context = new Context();
+//
+//            Scenario.Define(context)
+//                .WithEndpoint<TimeoutHandlingEndpoint>(b => b
+//                    .CustomConfig(configure => Configure.Transactions.Disable())
+//                    .Given(bus =>
+//                    {
+//                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+//                    }))
+//                .Done(c => c.AttemptedToRemoveTimeout && c.MessageReceived)
+//                .Run();
+//
+//            Assert.IsTrue(context.MessageReceived, "Message should be delivered although timeout processing fails");
+//            Assert.AreEqual(1, context.NumberOfProcessingAttempts, "Should not retry without transactions enabled");
+//            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+//        }
+//
+//        public class Context : ScenarioContext
+//        {
+//            public bool MessageReceived { get; set; }
+//
+//            public bool AttemptedToRemoveTimeout { get; set; }
+//
+//            public int NumberOfProcessingAttempts { get; set; }
+//        }
+//
+//        public class TimeoutHandlingEndpoint : EndpointConfigurationBuilder
+//        {
+//            public TimeoutHandlingEndpoint()
+//            {
+//                EndpointSetup<DefaultServer>();
+//            }
+//
+//            public class DelayedMessageHandler : IHandleMessages<MyMessage>
+//            {
+//                Context context;
+//
+//                public DelayedMessageHandler(Context context)
+//                {
+//                    this.context = context;
+//                }
+//
+//                public void Handle(MyMessage message)
+//                {
+//                    context.MessageReceived = true;
+//                }
+//            }
+//
+//            public class EndpointConfiguration : IWantToRunWhenConfigurationIsComplete
+//            {
+//                Context context;
+//                IPersistTimeouts originalPersister;
+//
+//                public EndpointConfiguration(Context context, IPersistTimeouts originalPersister)
+//                {
+//                    this.context = context;
+//                    this.originalPersister = originalPersister;
+//                }
+//
+//                public void Run()
+//                {
+//                    Configure.Component(b => new TimeoutPersistenceWrapper(originalPersister, originalPersister as IPersistTimeoutsV2, context), DependencyLifecycle.SingleInstance);
+//                }
+//            }
+//
+//            class TimeoutPersistenceWrapper : IPersistTimeouts, IPersistTimeoutsV2
+//            {
+//                IPersistTimeouts originalTimeoutPersister;
+//                IPersistTimeoutsV2 originalTimeoutPersisterV2;
+//                Context context;
+//
+//                public TimeoutPersistenceWrapper(IPersistTimeouts originalTimeoutPersister, IPersistTimeoutsV2 originalTimeoutPersisterV2, Context context)
+//                {
+//                    this.originalTimeoutPersister = originalTimeoutPersister;
+//                    this.originalTimeoutPersisterV2 = originalTimeoutPersisterV2;
+//                    this.context = context;
+//                }
+//
+//                public List<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+//                {
+//                    return originalTimeoutPersister.GetNextChunk(startSlice, out nextTimeToRunQuery);
+//                }
+//
+//                public void Add(TimeoutData timeout)
+//                {
+//                    originalTimeoutPersister.Add(timeout);
+//                }
+//
+//                public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+//                {
+//                    return originalTimeoutPersister.TryRemove(timeoutId, out timeoutData);
+//                }
+//
+//                public void RemoveTimeoutBy(Guid sagaId)
+//                {
+//                    originalTimeoutPersister.RemoveTimeoutBy(sagaId);
+//                }
+//
+//                public TimeoutData Peek(string timeoutId)
+//                {
+//                    context.NumberOfProcessingAttempts++;
+//                    return originalTimeoutPersisterV2.Peek(timeoutId);
+//                }
+//
+//                public bool TryRemove(string timeoutId)
+//                {
+//                    context.AttemptedToRemoveTimeout = true;
+//
+//                    using (var tx = new TransactionScope(TransactionScopeOption.Suppress))
+//                    {
+//                        // delete the timeout so it won't be available on retries
+//                        originalTimeoutPersisterV2.TryRemove(timeoutId);
+//                        tx.Complete();
+//                    }
+//
+//                    return false;
+//                }
+//            }
+//        }
+//
+//        [Serializable]
+//        public class MyMessage : IMessage
+//        {
+//        }
+//    }
+//}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_dispatching_deferred_message_fails_without_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_dispatching_deferred_message_fails_without_dtc.cs
@@ -1,0 +1,113 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_dispatching_deferred_message_fails_without_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_be_received()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<TimeoutHandlingEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.Defer(TimeSpan.FromSeconds(3), new MyMessage());
+                    }))
+                    .Done(c => c.MessageReceived)
+                    .Run();
+
+            Assert.IsTrue(context.SendingMessageFailedOnce);
+            Assert.IsTrue(context.MessageReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+
+            public bool SendingMessageFailedOnce { get; set; }
+        }
+
+        public class TimeoutHandlingEndpoint : EndpointConfigurationBuilder
+        {
+            public TimeoutHandlingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                }).AllowExceptions();
+            }
+
+            public class DelayedMessageHandler : IHandleMessages<MyMessage>
+            {
+                Context context;
+
+                public DelayedMessageHandler(Context context)
+                {
+                    this.context = context;
+                }
+
+                public void Handle(MyMessage message)
+                {
+                    context.MessageReceived = true;
+                }
+            }
+
+            public class EndpointConfiguration : IWantToRunWhenConfigurationIsComplete
+            {
+                Context context;
+                ISendMessages originalMessageSender;
+
+                public EndpointConfiguration(Context context, ISendMessages originalMessageSender)
+                {
+                    this.context = context;
+                    this.originalMessageSender = originalMessageSender;
+                }
+
+                public void Run()
+                {
+                    Configure.Component(b => new SenderWrapper(originalMessageSender, context), DependencyLifecycle.SingleInstance);
+                }
+            }
+
+            class SenderWrapper : ISendMessages
+            {
+                ISendMessages wrappedSender;
+                Context context;
+
+                public SenderWrapper(ISendMessages wrappedSender, Context context)
+                {
+                    this.wrappedSender = wrappedSender;
+                    this.context = context;
+                }
+
+                public void Send(TransportMessage message, Address address)
+                {
+                    string realtedTimeoutId;
+                    if (message.Headers.TryGetValue("NServiceBus.RelatedToTimeoutId", out realtedTimeoutId))
+                    {
+                        // dispatched message by timeout behavior
+                        // fail first attempt:
+                        if (!context.SendingMessageFailedOnce)
+                        {
+                            context.SendingMessageFailedOnce = true;
+                            throw new Exception("simulated exception");
+                        }
+                    }
+
+                    wrappedSender.Send(message, address);
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_no_timeout_persistence.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_no_timeout_persistence.cs
@@ -1,0 +1,96 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using AcceptanceTesting.Support;
+    using Config.ConfigurationSource;
+    using Hosting.Helpers;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_no_timeout_persistence : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<MinimalServer>(config =>
+                {
+                    config.DisableTimeoutManager();
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class MinimalServer : IEndpointSetupTemplate
+        {
+            public Configure GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource)
+            {
+                var settings = runDescriptor.Settings;
+
+                SetLoggingLibrary.Log4Net(null, new ContextAppender(runDescriptor.ScenarioContext, endpointConfiguration));
+
+
+                var types = GetTypesToUse(endpointConfiguration);
+
+                var config = Configure.With(types)
+                    .CustomConfigurationSource(configSource)
+                    .DefineBuilder(settings.GetOrNull("Builder"))
+                    .DefineSerializer(settings.GetOrNull("Serializer"))
+                    .DefineTransport(settings);
+
+                return config.UnicastBus();
+            }
+
+            static IEnumerable<Type> GetTypesToUse(EndpointConfiguration endpointConfiguration)
+            {
+                var assemblies = new AssemblyScanner().GetScannableAssemblies();
+
+                var types = assemblies.Assemblies
+                                      //exclude all test types by default
+                                      .Where(a => a != Assembly.GetExecutingAssembly())
+                                      .SelectMany(a => a.GetTypes());
+
+
+                types = types.Union(GetNestedTypeRecursive(endpointConfiguration.BuilderType.DeclaringType, endpointConfiguration.BuilderType));
+
+                types = types.Union(endpointConfiguration.TypesToInclude);
+
+                return types.Where(t => !endpointConfiguration.TypesToExclude.Contains(t)).ToList();
+            }
+
+            static IEnumerable<Type> GetNestedTypeRecursive(Type rootType, Type builderType)
+            {
+                yield return rootType;
+
+                if (typeof(IEndpointConfigurationFactory).IsAssignableFrom(rootType) && rootType != builderType)
+                    yield break;
+
+                foreach (var nestedType in rootType.GetNestedTypes(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic).SelectMany(t => GetNestedTypeRecursive(t, builderType)))
+                {
+                    yield return nestedType;
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_sql_transport_with_disabled_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_sql_transport_with_disabled_dtc.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Settings;
+    using NServiceBus.Timeout.Core;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_sql_transport_with_disabled_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_warning()
+        {
+            var context = new Context();
+
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                    .WithEndpoint<Endpoint>()
+                    .Done(c => c.EndpointsStarted)
+                    .Run())
+                    .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            StringAssert.Contains("You are using an outdated transport which can lead to message loss!", scenarioException.InnerException.Message);
+        }
+
+        [Test]
+        public void Endpoint_should_start_when_warning_suppressed()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(c => c
+                    .CustomConfig(configure => configure.SuppressOutdatedTransportWarning()))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Configurer.ConfigureComponent<UpdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                    config.UseTransport<OutdatedSqlServerTransport>();
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class OutdatedSqlServerTransport : TransportDefinition
+        {
+            // needs to contain SqlServer in the name
+            public OutdatedSqlServerTransport()
+            {
+                HasSupportForDistributedTransactions = true;
+            }
+        }
+
+        public class OutdatedSqlServerTransportConfiguration : IConfigureTransport<OutdatedSqlServerTransport>
+        {
+            public void Configure(Configure config)
+            {
+                var selectedTransportDefinition = new OutdatedSqlServerTransport();
+                SettingsHolder.Set("NServiceBus.Transport.SelectedTransport", selectedTransportDefinition);
+                config.Configurer.RegisterSingleton<TransportDefinition>(selectedTransportDefinition);
+            }
+        }
+    }
+
+    
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_sql_transport_with_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_sql_transport_with_dtc.cs
@@ -1,0 +1,59 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Settings;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_sql_transport_with_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Configurer.ConfigureComponent<UpdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                    config.UseTransport<OutdatedSqlServerTransport>();
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class OutdatedSqlServerTransport : TransportDefinition
+        {
+            // needs to contain SqlServer in the name
+            public OutdatedSqlServerTransport()
+            {
+                HasSupportForDistributedTransactions = true;
+            }
+        }
+
+        public class OutdatedSqlServerTransportConfiguration : IConfigureTransport<OutdatedSqlServerTransport>
+        {
+            public void Configure(Configure config)
+            {
+                var selectedTransportDefinition = new OutdatedSqlServerTransport();
+                SettingsHolder.Set("NServiceBus.Transport.SelectedTransport", selectedTransportDefinition);
+                config.Configurer.RegisterSingleton<TransportDefinition>(selectedTransportDefinition);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs
@@ -1,0 +1,57 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Timeout.Core;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_warning()
+        {
+            var context = new Context();
+
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run())
+                .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            StringAssert.Contains("You are using an outdated timeout persistence which can lead to message loss!", scenarioException.InnerException.Message);
+        }
+
+        [Test]
+        public void Endpoint_should_start_when_warning_suppressed()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(c => c
+                    .CustomConfig(config => config.SuppressOutdatedTimeoutPersistenceWarning()))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Configurer.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        } 
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs
@@ -1,0 +1,39 @@
+﻿//namespace NServiceBus.AcceptanceTests.Timeouts
+//{
+//    using NServiceBus.AcceptanceTesting;
+//    using NServiceBus.AcceptanceTests.EndpointTemplates;
+//    using NUnit.Framework;
+//
+//    [CoreConcern]
+//    public class When_endpoint_uses_outdated_timeout_persistence_with_dtc : NServiceBusAcceptanceTest
+//    {
+//        [Test]
+//        public void Endpoint_should_start()
+//        {
+//            var context = new Context();
+//
+//            Scenario.Define(context)
+//                .WithEndpoint<Endpoint>()
+//                .Done(c => c.EndpointsStarted)
+//                .Run();
+//
+//            Assert.IsTrue(context.EndpointsStarted);
+//        }
+//
+//        public class Endpoint : EndpointConfigurationBuilder
+//        {
+//            public Endpoint()
+//            {
+//                EndpointSetup<DefaultServer>(config =>
+//                {
+//                    config.Configurer.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+//                    Configure.Transactions.Advanced(s => s.EnableDistributedTransactions());
+//                });
+//            }
+//        }
+//
+//        public class Context : ScenarioContext
+//        {
+//        } 
+//    }
+//}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Settings;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_timeout_persistence_without_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_warning()
+        {
+            var context = new Context();
+
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                    .WithEndpoint<Endpoint>()
+                    .Done(c => c.EndpointsStarted)
+                    .Run())
+                    .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            StringAssert.Contains("You are using an outdated timeout persistence which can lead to message loss!", scenarioException.InnerException.Message);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.UseTransport<NonDtcTransportDefinition>();
+                    config.Configurer.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        class NonDtcTransportDefinition : TransportDefinition
+        {
+            public NonDtcTransportDefinition()
+            {
+                HasSupportForDistributedTransactions = false;
+            }
+        }
+
+        class NonDtcTransport : IConfigureTransport<NonDtcTransportDefinition>
+        {
+            public void Configure(Configure config)
+            {
+                var selectedTransportDefinition = Activator.CreateInstance<NonDtcTransportDefinition>();
+                SettingsHolder.Set("NServiceBus.Transport.SelectedTransport", selectedTransportDefinition);
+                config.Configurer.RegisterSingleton<TransportDefinition>(selectedTransportDefinition);
+            }
+        } 
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs
@@ -1,62 +1,62 @@
-﻿namespace NServiceBus.AcceptanceTests.Timeouts
-{
-    using System;
-    using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTesting.Support;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.Settings;
-    using NServiceBus.Transports;
-    using NUnit.Framework;
-
-    public class When_endpoint_uses_outdated_timeout_persistence_without_dtc : NServiceBusAcceptanceTest
-    {
-        [Test]
-        public void Endpoint_should_not_start_and_show_warning()
-        {
-            var context = new Context();
-
-            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
-                    .WithEndpoint<Endpoint>()
-                    .Done(c => c.EndpointsStarted)
-                    .Run())
-                    .InnerException as ScenarioException;
-
-            Assert.IsFalse(context.EndpointsStarted);
-            StringAssert.Contains("You are using an outdated timeout persistence which can lead to message loss!", scenarioException.InnerException.Message);
-        }
-
-        public class Endpoint : EndpointConfigurationBuilder
-        {
-            public Endpoint()
-            {
-                EndpointSetup<DefaultServer>(config =>
-                {
-                    config.UseTransport<NonDtcTransportDefinition>();
-                    config.Configurer.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
-                });
-            }
-        }
-
-        public class Context : ScenarioContext
-        {
-        }
-
-        class NonDtcTransportDefinition : TransportDefinition
-        {
-            public NonDtcTransportDefinition()
-            {
-                HasSupportForDistributedTransactions = false;
-            }
-        }
-
-        class NonDtcTransport : IConfigureTransport<NonDtcTransportDefinition>
-        {
-            public void Configure(Configure config)
-            {
-                var selectedTransportDefinition = Activator.CreateInstance<NonDtcTransportDefinition>();
-                SettingsHolder.Set("NServiceBus.Transport.SelectedTransport", selectedTransportDefinition);
-                config.Configurer.RegisterSingleton<TransportDefinition>(selectedTransportDefinition);
-            }
-        } 
-    }
-}
+﻿//namespace NServiceBus.AcceptanceTests.Timeouts
+//{
+//    using System;
+//    using NServiceBus.AcceptanceTesting;
+//    using NServiceBus.AcceptanceTesting.Support;
+//    using NServiceBus.AcceptanceTests.EndpointTemplates;
+//    using NServiceBus.Settings;
+//    using NServiceBus.Transports;
+//    using NUnit.Framework;
+//
+//    public class When_endpoint_uses_outdated_timeout_persistence_without_dtc : NServiceBusAcceptanceTest
+//    {
+//        [Test]
+//        public void Endpoint_should_not_start_and_show_warning()
+//        {
+//            var context = new Context();
+//
+//            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+//                    .WithEndpoint<Endpoint>()
+//                    .Done(c => c.EndpointsStarted)
+//                    .Run())
+//                    .InnerException as ScenarioException;
+//
+//            Assert.IsFalse(context.EndpointsStarted);
+//            StringAssert.Contains("You are using an outdated timeout persistence which can lead to message loss!", scenarioException.InnerException.Message);
+//        }
+//
+//        public class Endpoint : EndpointConfigurationBuilder
+//        {
+//            public Endpoint()
+//            {
+//                EndpointSetup<DefaultServer>(config =>
+//                {
+//                    config.UseTransport<NonDtcTransportDefinition>();
+//                    config.Configurer.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+//                });
+//            }
+//        }
+//
+//        public class Context : ScenarioContext
+//        {
+//        }
+//
+//        class NonDtcTransportDefinition : TransportDefinition
+//        {
+//            public NonDtcTransportDefinition()
+//            {
+//                HasSupportForDistributedTransactions = false;
+//            }
+//        }
+//
+//        class NonDtcTransport : IConfigureTransport<NonDtcTransportDefinition>
+//        {
+//            public void Configure(Configure config)
+//            {
+//                var selectedTransportDefinition = Activator.CreateInstance<NonDtcTransportDefinition>();
+//                SettingsHolder.Set("NServiceBus.Transport.SelectedTransport", selectedTransportDefinition);
+//                config.Configurer.RegisterSingleton<TransportDefinition>(selectedTransportDefinition);
+//            }
+//        } 
+//    }
+//}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_updated_sql_transport_with_disabled_dtc.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_updated_sql_transport_with_disabled_dtc.cs
@@ -1,0 +1,61 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Settings;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_updated_sql_transport_with_disabled_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Configurer.ConfigureComponent<UpdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                    config.UseTransport<UpdatedSqlServerTransport>();
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class UpdatedSqlServerTransport : TransportDefinition
+        {
+            // needs to contain SqlServer in the name
+            public UpdatedSqlServerTransport()
+            {
+                HasSupportForDistributedTransactions = true;
+                SettingsHolder.Set("NServiceBus.Transport.SupportsNativeTransactionSuppression", true);
+            }
+        }
+
+        public class UpdatedSqlServerTransportConfiguration : IConfigureTransport<UpdatedSqlServerTransport>
+        {
+            public void Configure(Configure config)
+            {
+                var selectedTransportDefinition = new UpdatedSqlServerTransport();
+                SettingsHolder.Set("NServiceBus.Transport.SelectedTransport", selectedTransportDefinition);
+                config.Configurer.RegisterSingleton<TransportDefinition>(selectedTransportDefinition);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_updated_timeout_persistence.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_updated_timeout_persistence.cs
@@ -1,0 +1,38 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_updated_timeout_persistence : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Configurer.ConfigureComponent<UpdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+                    Configure.Transactions.Advanced(s => s.DisableDistributedTransactions());
+                });
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }  
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/FakePromotableResourceManager.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/FakePromotableResourceManager.cs
@@ -1,0 +1,54 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+
+    public class FakePromotableResourceManager : IPromotableSinglePhaseNotification, IEnlistmentNotification
+    {
+        public static Guid ResourceManagerId = Guid.Parse("6f057e24-a0d8-4c95-b091-b8dc9a916fa4");
+
+        public void Prepare(PreparingEnlistment preparingEnlistment)
+        {
+            preparingEnlistment.Prepared();
+        }
+
+        public void Commit(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+
+        public void Rollback(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+
+        public void InDoubt(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+
+
+        public void Initialize()
+        {
+        }
+
+        public void SinglePhaseCommit(SinglePhaseEnlistment singlePhaseEnlistment)
+        {
+            singlePhaseEnlistment.Committed();
+        }
+
+        public void Rollback(SinglePhaseEnlistment singlePhaseEnlistment)
+        {
+            singlePhaseEnlistment.Done();
+        }
+
+        public byte[] Promote()
+        {
+            return TransactionInterop.GetTransmitterPropagationToken(new CommittableTransaction());
+
+        }
+
+
+    }
+
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_dtc_disabled.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_dtc_disabled.cs
@@ -1,0 +1,66 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_with_dtc_disabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_escalate_a_single_durable_rm_to_dtc_tx()
+        {
+
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonDTCEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.HandlerInvoked)
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c =>
+                        {
+                            //this check mainly applies to MSMQ who creates a DTC tx right of the bat if DTC is on
+                            Assert.AreEqual(Guid.Empty, c.DistributedIdentifierBefore, "No DTC tx should exist before enlistment");
+                            Assert.True(c.CanEnlistPromotable, "A promotable RM should be able to enlist");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerInvoked { get; set; }
+
+            public Guid DistributedIdentifierBefore { get; set; }
+
+            public bool CanEnlistPromotable { get; set; }
+        }
+
+        public class NonDTCEndpoint : EndpointConfigurationBuilder
+        {
+            public NonDTCEndpoint()
+            {
+                Configure.Transactions.Advanced(a => a.DisableDistributedTransactions());
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessage messageThatIsEnlisted)
+                {
+                    Context.DistributedIdentifierBefore = Transaction.Current.TransactionInformation.DistributedIdentifier;
+
+                    Context.CanEnlistPromotable = Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager());
+
+                    Context.HandlerInvoked = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_dtc_enabled.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_dtc_enabled.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_with_dtc_enabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_enlist_the_receive_in_the_dtc_tx()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<DTCEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.HandlerInvoked)
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c => Assert.False(c.CanEnlistPromotable, "There should exists a DTC tx"))
+                    .Run();
+        }
+
+        [Test]
+        public void Basic_assumptions_promotable_should_fail_if_durable_already_exists()
+        {
+            using (var tx = new TransactionScope())
+            {
+                Transaction.Current.EnlistDurable(FakePromotableResourceManager.ResourceManagerId, new FakePromotableResourceManager(), EnlistmentOptions.None);
+                Assert.False(Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager()));
+
+                tx.Complete();
+            }
+        }
+
+
+        [Test]
+        public void Basic_assumptions_second_promotable_should_fail()
+        {
+            using (var tx = new TransactionScope())
+            {
+                Assert.True(Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager()));
+
+                Assert.False(Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager()));
+
+                tx.Complete();
+            }
+        }
+
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerInvoked { get; set; }
+
+            public bool CanEnlistPromotable { get; set; }
+        }
+
+        public class DTCEndpoint : EndpointConfigurationBuilder
+        {
+            public DTCEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessage messageThatIsEnlisted)
+                {
+                    Context.CanEnlistPromotable = Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager());
+                    Context.HandlerInvoked = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_the_default_settings.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_the_default_settings.cs
@@ -1,0 +1,53 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_with_the_default_settings : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_wrap_the_handler_pipeline_with_a_transactionscope()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<TransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.HandlerInvoked)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.AmbientTransactionExists, "There should exist an ambient transaction"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool AmbientTransactionExists { get; set; }
+            public bool HandlerInvoked { get; set; }
+        }
+
+        public class TransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public TransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessage messageThatIsEnlisted)
+                {
+                    Context.AmbientTransactionExists = (Transaction.Current != null);
+                    Context.HandlerInvoked = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_transactions_disabled.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_receiving_a_message_with_transactions_disabled.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_receiving_a_message_with_transactions_disabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_roll_the_message_back_to_the_queue_in_case_of_failure()
+        {
+
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.TestComplete)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.AreEqual(1, c.TimesCalled, "Should not retry the message"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool TestComplete { get; set; }
+
+            public int TimesCalled { get; set; }
+        }
+
+        public class NonTransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public NonTransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Transactions.Disable())
+                    .AllowExceptions();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+                public void Handle(MyMessage message)
+                {
+                    Context.TimesCalled++;
+
+                    using (new TransactionScope(TransactionScopeOption.Suppress))
+                    {
+                        Bus.SendLocal(new CompleteTest());
+                    }
+
+                    throw new Exception("Simulated exception");
+                }
+            }
+
+            public class CompleteTestHandler : IHandleMessages<CompleteTest>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(CompleteTest message)
+                {
+                    Context.TestComplete = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+        [Serializable]
+        public class CompleteTest : ICommand
+        {
+        }
+
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_sending_a_message_from_a_non_transactional_endpoint_with_a_ambient_transaction_enabled.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_sending_a_message_from_a_non_transactional_endpoint_with_a_ambient_transaction_enabled.cs
@@ -1,0 +1,91 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_sending_a_message_from_a_non_transactional_endpoint_with_a_ambient_transaction_enabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_roll_the_message_back_to_the_queue_in_case_of_failure()
+        {
+
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.TestComplete)
+                    .Repeat(r => r.For<AllDtcTransports>()) 
+                    .Should(c => Assert.False(c.MessageEnlistedInTheAmbientTxReceived, "The enlisted bus.Send should not commit"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool TestComplete { get; set; }
+
+            public bool MessageEnlistedInTheAmbientTxReceived { get; set; }
+        }
+
+        public class NonTransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public NonTransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        Configure.Transactions.Disable();
+                        Configure.Transactions.Advanced(t => t.WrapHandlersExecutionInATransactionScope());
+                    })
+                    .AllowExceptions();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+                public void Handle(MyMessage message)
+                {
+                    Bus.SendLocal(new CompleteTest
+                        {
+                            EnlistedInTheAmbientTx = true
+                        });
+
+                    using (new TransactionScope(TransactionScopeOption.Suppress))
+                    {
+                        Bus.SendLocal(new CompleteTest());
+                    }
+
+                    throw new Exception("Simulated exception");
+                }
+            }
+
+            public class CompleteTestHandler : IHandleMessages<CompleteTest>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(CompleteTest message)
+                {
+                    if (!Context.MessageEnlistedInTheAmbientTxReceived)
+                        Context.MessageEnlistedInTheAmbientTxReceived = message.EnlistedInTheAmbientTx;
+
+                    Context.TestComplete = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+        [Serializable]
+        public class CompleteTest : ICommand
+        {
+            public bool EnlistedInTheAmbientTx { get; set; }
+        }
+
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_sending_messages_within_an_ambient_transaction.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Transactions/When_sending_messages_within_an_ambient_transaction.cs
@@ -1,0 +1,122 @@
+﻿namespace NServiceBus.AcceptanceTests.Transactions
+{
+    using System;
+    using System.Transactions;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_sending_messages_within_an_ambient_transaction : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_deliver_them_until_the_commit_phase()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<TransactionalEndpoint>(b => b.Given((bus, context) =>
+                        {
+                            using (var tx = new TransactionScope())
+                            {
+                                bus.Send(new MessageThatIsEnlisted { SequenceNumber = 1 });
+                                bus.Send(new MessageThatIsEnlisted { SequenceNumber = 2 });
+
+                                //send another message as well so that we can check the order in the receiver
+                                using (new TransactionScope(TransactionScopeOption.Suppress))
+                                {
+                                    bus.Send(new MessageThatIsNotEnlisted());
+                                }
+
+                                tx.Complete();
+                            }
+                        }))
+                    .Done(c => c.MessageThatIsNotEnlistedHandlerWasCalled && c.TimesCalled >= 2)
+                    .Repeat(r => r.For(Transports.Default)) //not stable for sqlserver
+                    .Should(c => Assert.AreEqual(1, c.SequenceNumberOfFirstMessage,"The transport should preserve the order in which the transactional messages are delivered to the queuing system"))
+                    .Run();
+        }
+
+        [Test]
+        public void Should_not_deliver_them_on_rollback()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<TransactionalEndpoint>(b => b.Given(bus =>
+                        {
+                            using (new TransactionScope())
+                            {
+                                bus.Send(new MessageThatIsEnlisted());
+
+                                //rollback
+                            }
+
+                            bus.Send(new MessageThatIsNotEnlisted());
+
+                        }))
+                    .Done(c => c.MessageThatIsNotEnlistedHandlerWasCalled)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.False(c.MessageThatIsEnlistedHandlerWasCalled, "The transactional handler should not be called"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageThatIsEnlistedHandlerWasCalled { get; set; }
+
+            public bool MessageThatIsNotEnlistedHandlerWasCalled { get; set; }
+            public int TimesCalled { get; set; }
+
+            public int SequenceNumberOfFirstMessage { get; set; }
+
+            public bool NonTransactionalHandlerCalledFirst { get; set; }
+        }
+
+        public class TransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public TransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MessageThatIsEnlisted>(typeof(TransactionalEndpoint))
+                    .AddMapping<MessageThatIsNotEnlisted>(typeof(TransactionalEndpoint));
+            }
+
+            public class MessageThatIsEnlistedHandler : IHandleMessages<MessageThatIsEnlisted>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageThatIsEnlisted messageThatIsEnlisted)
+                {
+                    Context.MessageThatIsEnlistedHandlerWasCalled = true;
+                    Context.TimesCalled++;
+
+                    if (Context.SequenceNumberOfFirstMessage == 0)
+                    {
+                        Context.SequenceNumberOfFirstMessage = messageThatIsEnlisted.SequenceNumber;
+                    }
+                }
+            }
+
+            public class MessageThatIsNotEnlistedHandler : IHandleMessages<MessageThatIsNotEnlisted>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageThatIsNotEnlisted messageThatIsNotEnlisted)
+                {
+                    Context.MessageThatIsNotEnlistedHandlerWasCalled = true;
+                    Context.NonTransactionalHandlerCalledFirst = !Context.MessageThatIsEnlistedHandlerWasCalled;
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class MessageThatIsEnlisted : ICommand
+        {
+            public int SequenceNumber { get; set; }
+        }
+        [Serializable]
+        public class MessageThatIsNotEnlisted : ICommand
+        {
+        }
+
+
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/App_Packages/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
@@ -1,0 +1,124 @@
+﻿namespace NServiceBus.AcceptanceTests.Versioning
+{
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using PubSub;
+    using ScenarioDescriptors;
+
+    public class When_multiple_versions_of_a_message_is_published : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_deliver_is_to_both_v1_and_vX_subscribers()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<V2Publisher>(b =>
+                        b.Given((bus, context) => Subscriptions.OnEndpointSubscribed(s =>
+                            {
+                                if (s.SubscriberReturnAddress.Queue.Contains("V1Subscriber"))
+                                    context.V1Subscribed = true;
+
+                                if (s.SubscriberReturnAddress.Queue.Contains("V2Subscriber"))
+                                    context.V2Subscribed = true;
+                            })
+                            )
+                             .When(c => c.V1Subscribed && c.V2Subscribed, (bus, c) => bus.Publish<V2Event>(e =>
+                                 {
+                                     e.SomeData = 1;
+                                     e.MoreInfo = "dasd";
+                                 })))
+                    .WithEndpoint<V1Subscriber>(b => b.Given((bus,c) =>
+                        {
+                            bus.Subscribe<V1Event>();
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                c.V1Subscribed = true;
+                        }))
+                    .WithEndpoint<V2Subscriber>(b => b.Given((bus,c) =>
+                        {
+                            bus.Subscribe<V2Event>();
+                            if (!Feature.IsEnabled<MessageDrivenSubscriptions>())
+                                c.V2Subscribed = true;
+                        }))
+                    .Done(c => c.V1SubscriberGotTheMessage && c.V2SubscriberGotTheMessage)
+                    .Repeat(r =>//broken for active mq until #1098 is fixed
+                                    r.For<AllSerializers>(Serializers.Binary)) //versioning isn't supported for binary serialization
+                    .Should(c =>
+                        {
+                            //put asserts in here if needed
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool V1SubscriberGotTheMessage { get; set; }
+
+            public bool V2SubscriberGotTheMessage { get; set; }
+
+            public bool V1Subscribed { get; set; }
+
+            public bool V2Subscribed { get; set; }
+        }
+
+        public class V2Publisher : EndpointConfigurationBuilder
+        {
+            public V2Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+
+            }
+        }
+        public class V1Subscriber : EndpointConfigurationBuilder
+        {
+            public V1Subscriber()
+            {
+                EndpointSetup<DefaultServer>()
+                    .ExcludeType<V2Event>()
+                    .AddMapping<V1Event>(typeof(V2Publisher));
+
+            }
+
+
+            class V1Handler:IHandleMessages<V1Event>
+            {
+                public Context Context { get; set; }
+                public void Handle(V1Event message)
+                {
+                    Context.V1SubscriberGotTheMessage = true;
+                }
+            }
+        }
+
+
+        public class V2Subscriber : EndpointConfigurationBuilder
+        {
+            public V2Subscriber()
+            {
+                EndpointSetup<DefaultServer>()
+                     .AddMapping<V2Event>(typeof(V2Publisher));
+            }
+
+            class V2Handler : IHandleMessages<V2Event>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V2Event message)
+                {
+                    Context.V2SubscriberGotTheMessage = true;
+                }
+            }
+        }
+
+
+        public interface V1Event : IEvent
+        {
+            int SomeData { get; set; }
+        }
+
+        public interface V2Event : V1Event
+        {
+            string MoreInfo { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/NServiceBus.Azure.WindowsAzureStorageQueues.AcceptanceTests.csproj
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/NServiceBus.Azure.WindowsAzureStorageQueues.AcceptanceTests.csproj
@@ -64,7 +64,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="ripple.dependencies.config" />
+    <None Include="ripple.dependencies.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Packages\NServiceBus.AcceptanceTests\**\*.cs" />
@@ -75,6 +77,7 @@
       <Name>NServiceBus.Azure.Transports.WindowsAzureStorageQueues</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/Properties/AssemblyInfo.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/Properties/AssemblyInfo.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+//[assembly: AssemblyVersion("1.0.0.0")]
+//[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/ripple.dependencies.config
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance/ripple.dependencies.config
@@ -3,4 +3,3 @@ NUnit
 NServiceBus
 NServiceBus.Interfaces
 NServiceBus.AcceptanceTesting
-NServiceBus.AcceptanceTests.Sources

--- a/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues/NamingConventions/AzureQueueNamingConvention.cs
+++ b/src/NServiceBus.Azure.Transports.WindowsAzureStorageQueues/NamingConventions/AzureQueueNamingConvention.cs
@@ -9,12 +9,15 @@ namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues
     {
         public static Func<string, string> Apply = queueName =>
         {
+            // ReSharper disable once RedundantNameQualifier
             var configSection = NServiceBus.Configure.GetConfigSection<AzureQueueConfig>();
 
             if (configSection != null && !string.IsNullOrEmpty(configSection.QueueName))
             {
+                // ReSharper disable once RedundantCast
                 queueName = (string) configSection.QueueName;
 
+                // ReSharper disable once RedundantCast
                 if ((bool) configSection.QueuePerInstance)
                 {
                     SettingsHolder.SetDefault("ScaleOut.UseSingleBrokerQueue", false);

--- a/src/NServiceBus.Azure.sln
+++ b/src/NServiceBus.Azure.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30324.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Azure", "NServiceBus.Azure\NServiceBus.Azure.csproj", "{12F1D9F1-0A2C-4442-8D18-67DD096C6300}"
 EndProject
@@ -20,6 +20,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Azure.WindowsAzureStorageQueues.AcceptanceTests", "NServiceBus.Azure.Transports.WindowsAzureStorageQueues.Acceptance\NServiceBus.Azure.WindowsAzureStorageQueues.AcceptanceTests.csproj", "{09996CDC-90AC-442F-A6CE-601F37CD1352}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AcceptanceTests", "AcceptanceTests", "{C52BC8D5-E041-4A46-8983-8A0C6ABF7C98}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.AzureStoragePersistence.Tests", "NServiceBus.AzureStoragePersistence.Tests\NServiceBus.AzureStoragePersistence.Tests.csproj", "{D577B035-4D84-44C6-B912-765827BD39A2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,6 +61,10 @@ Global
 		{09996CDC-90AC-442F-A6CE-601F37CD1352}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{09996CDC-90AC-442F-A6CE-601F37CD1352}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{09996CDC-90AC-442F-A6CE-601F37CD1352}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D577B035-4D84-44C6-B912-765827BD39A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D577B035-4D84-44C6-B912-765827BD39A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D577B035-4D84-44C6-B912-765827BD39A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D577B035-4D84-44C6-B912-765827BD39A2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,5 +72,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{54FCA3C9-F153-4FDF-A7F6-46595275AE6E} = {C52BC8D5-E041-4A46-8983-8A0C6ABF7C98}
 		{09996CDC-90AC-442F-A6CE-601F37CD1352} = {C52BC8D5-E041-4A46-8983-8A0C6ABF7C98}
+		{D577B035-4D84-44C6-B912-765827BD39A2} = {C52BC8D5-E041-4A46-8983-8A0C6ABF7C98}
 	EndGlobalSection
 EndGlobal

--- a/src/NServiceBus.Azure/ConfigureAzureBlobStorageDataBus.cs
+++ b/src/NServiceBus.Azure/ConfigureAzureBlobStorageDataBus.cs
@@ -3,7 +3,6 @@ namespace NServiceBus
     using Config;
     using DataBus;
     using DataBus.Azure.BlobStorage;
-    using Microsoft.WindowsAzure.Storage.Blob;
     using CloudStorageAccount = Microsoft.WindowsAzure.Storage.CloudStorageAccount;
 
     /// <summary>

--- a/src/NServiceBus.Azure/ConfigureAzureIntegration.cs
+++ b/src/NServiceBus.Azure/ConfigureAzureIntegration.cs
@@ -11,6 +11,7 @@ namespace NServiceBus
 
         public static Configure AzureConfigurationSource(this Configure config, string configurationPrefix)
         {
+            // ReSharper disable once UseObjectOrCollectionInitializer
             var azureConfigSource = new AzureConfigurationSource(new AzureConfigurationSettings());
             azureConfigSource.ConfigurationPrefix = configurationPrefix;
             return config.CustomConfigurationSource(azureConfigSource);

--- a/src/NServiceBus.Azure/ConfigureAzureSagaPersister.cs
+++ b/src/NServiceBus.Azure/ConfigureAzureSagaPersister.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NServiceBus.Config;
+﻿using NServiceBus.Config;
 
 namespace NServiceBus
 {

--- a/src/NServiceBus.Azure/Logging/Azure/TraceLoggerFactory.cs
+++ b/src/NServiceBus.Azure/Logging/Azure/TraceLoggerFactory.cs
@@ -6,11 +6,13 @@ namespace NServiceBus.Logging.Loggers
     {
         public ILog GetLogger(Type type)
         {
+            // ReSharper disable once RedundantCast
             return (ILog)new TraceLogger();
         }
 
         public ILog GetLogger(string name)
         {
+            // ReSharper disable once RedundantCast
             return (ILog)new TraceLogger();
         }
     }

--- a/src/NServiceBus.Azure/Timeout/TimeoutLogic/AutoRenewLease.cs
+++ b/src/NServiceBus.Azure/Timeout/TimeoutLogic/AutoRenewLease.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading;
-using System.Net;
 
 namespace NServiceBus.Azure
 {

--- a/src/NServiceBus.Azure/Timeout/TimeoutLogic/LeaseExtensions.cs
+++ b/src/NServiceBus.Azure/Timeout/TimeoutLogic/LeaseExtensions.cs
@@ -5,7 +5,6 @@ namespace NServiceBus.Azure
 {
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Blob;
-    using Microsoft.WindowsAzure.Storage.Blob.Protocol;
 
     public static class LeaseBlobExtensions
     {

--- a/src/NServiceBus.Azure/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Azure/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -6,7 +6,6 @@
     using System.Data.Services.Client;
     using System.IO;
     using System.Linq;
-    using System.Net;
     using System.Security.Cryptography;
     using System.Text;
     using System.Web.Script.Serialization;

--- a/src/NServiceBus.Azure/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Azure/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -6,13 +6,13 @@
     using System.Data.Services.Client;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Security.Cryptography;
     using System.Text;
     using System.Web.Script.Serialization;
     using Logging;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Blob;
-    using Microsoft.WindowsAzure.Storage.RetryPolicies;
     using Microsoft.WindowsAzure.Storage.Table.DataServices;
     using Timeout.Core;
     using RuntimeEnvironment = Support.RuntimeEnvironment;
@@ -167,8 +167,19 @@
 
         public bool TryRemove(string timeoutId)
         {
-            TimeoutData data;
-            return TryRemove(timeoutId, out data);
+            try
+            {
+                TimeoutData data;
+                return TryRemove(timeoutId, out data);
+            }
+            catch (DataServiceRequestException) // table entries were already removed
+            {
+               return false;
+            }
+            catch (StorageException) // blob file was already removed
+            {
+                return false;
+            }
         }
 
         public bool TryRemove(string timeoutId, out TimeoutData timeoutData)

--- a/src/NServiceBus.AzureStoragePersistence.Tests/AzurePersistenceTests.cs
+++ b/src/NServiceBus.AzureStoragePersistence.Tests/AzurePersistenceTests.cs
@@ -1,0 +1,18 @@
+﻿namespace NServiceBus.AzureStoragePersistence.Tests
+{
+    using System;
+
+    public class AzurePersistenceTests
+    {
+        public static string GetConnectionString()
+        {
+            var environmentVariable = Environment.GetEnvironmentVariable("AzureStorageQueue.ConnectionString");
+            if (environmentVariable != null)
+            {
+                return environmentVariable;
+            }
+
+            throw new Exception("Can't run Azure persistence tests - environment variable `AzureStorageQueue.ConnectionString` with Azure storage connection string was not found.");
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence.Tests/NServiceBus.AzureStoragePersistence.Tests.csproj
+++ b/src/NServiceBus.AzureStoragePersistence.Tests/NServiceBus.AzureStoragePersistence.Tests.csproj
@@ -71,7 +71,9 @@
   <ItemGroup>
     <Compile Include="AzurePersistenceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Test_Helper.cs" />
     <Compile Include="Timeouts\When_removing_timeouts_from_the_storage.cs" />
+    <Compile Include="Timeouts\When_timeout_is_added.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ripple.dependencies.config">

--- a/src/NServiceBus.AzureStoragePersistence.Tests/NServiceBus.AzureStoragePersistence.Tests.csproj
+++ b/src/NServiceBus.AzureStoragePersistence.Tests/NServiceBus.AzureStoragePersistence.Tests.csproj
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D577B035-4D84-44C6-B912-765827BD39A2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NServiceBus.AzureStoragePersistence.Tests</RootNamespace>
+    <AssemblyName>NServiceBus.AzureStoragePersistence.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Services.Client\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=3.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="NServiceBus">
+      <HintPath>..\packages\NServiceBus.Interfaces\lib\net40\NServiceBus.dll</HintPath>
+    </Reference>
+    <Reference Include="NServiceBus.Core">
+      <HintPath>..\packages\NServiceBus\lib\net40\NServiceBus.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AzurePersistenceTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Timeouts\When_removing_timeouts_from_the_storage.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="ripple.dependencies.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Azure\NServiceBus.Azure.csproj">
+      <Project>{12F1D9F1-0A2C-4442-8D18-67DD096C6300}</Project>
+      <Name>NServiceBus.Azure</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NServiceBus.AzureStoragePersistence.Tests/NServiceBus.AzureStoragePersistence.Tests.csproj
+++ b/src/NServiceBus.AzureStoragePersistence.Tests/NServiceBus.AzureStoragePersistence.Tests.csproj
@@ -30,6 +30,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Data.OData\lib\net40\Microsoft.Data.OData.dll</HintPath>

--- a/src/NServiceBus.AzureStoragePersistence.Tests/Properties/AssemblyInfo.cs
+++ b/src/NServiceBus.AzureStoragePersistence.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NServiceBus.AzureStoragePersistence.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NServiceBus.AzureStoragePersistence.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f1d80d2b-011e-4a17-9a6c-78d3f1c5093b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NServiceBus.AzureStoragePersistence.Tests/Test_Helper.cs
+++ b/src/NServiceBus.AzureStoragePersistence.Tests/Test_Helper.cs
@@ -1,0 +1,116 @@
+﻿namespace NServiceBus.AzureStoragePersistence.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Blob;
+    using Microsoft.WindowsAzure.Storage.RetryPolicies;
+    using Microsoft.WindowsAzure.Storage.Table;
+    using NServiceBus.Azure;
+    using NServiceBus.Config;
+    using NServiceBus.Timeout.Core;
+    using NUnit.Framework;
+
+    static class Test_Helper
+    {
+        internal static TimeoutPersister Create_TimeoutPersister()
+        {
+            TimeoutPersister persister = null;
+            try
+            {
+                persister = new TimeoutPersister
+                {
+                    PartitionKeyScope = new AzureTimeoutPersisterConfig().PartitionKeyScope,
+                    ConnectionString = AzurePersistenceTests.GetConnectionString()
+                };
+            }
+            catch (WebException exception)
+            {
+                // Azure blob container CreateIfNotExists() can falsly report HTTP 409 error, swallow it
+                if (exception.Status != WebExceptionStatus.ProtocolError || (exception.Response is HttpWebResponse && ((HttpWebResponse)exception.Response).StatusCode != HttpStatusCode.NotFound))
+                {
+                    throw;
+                }
+            }
+            return persister;
+        }
+
+
+        internal static TimeoutData Generate_Timeout_With_Headers()
+        {
+            return new TimeoutData
+            {
+                Time = DateTime.UtcNow.AddYears(-1),
+                Destination = new Address("timeouts", "some_azure_connection_string"),
+                SagaId = Guid.NewGuid(),
+                State = new byte[] { 1, 2, 3, 4 },
+                Headers = new Dictionary<string, string>
+                    {
+                        {"Prop1", "1234"},
+                        {"Prop2", "text"}
+                    },
+                OwningTimeoutManager = Configure.EndpointName
+            };
+        }
+
+        internal static TimeoutData Getnerate_Timeout_With_Saga_Id(Guid sagaId)
+        {
+            var timeoutWithHeaders1 = Generate_Timeout_With_Headers();
+            timeoutWithHeaders1.SagaId = sagaId;
+            return timeoutWithHeaders1;
+        }
+
+        internal static List<Tuple<string, DateTime>> Get_All_Timeouts_Using_GetNextChunk(TimeoutPersister persister)
+        {
+            DateTime nextRun;
+            var timeouts = persister.GetNextChunk(DateTime.Now.AddYears(-3), out nextRun).ToList();
+            return timeouts;
+        }
+
+        public static void Assert_All_Timeouts_Have_Been_Removed(TimeoutPersister timeoutPersister)
+        {
+            var cloudStorageAccount = CloudStorageAccount.Parse(timeoutPersister.ConnectionString);
+
+            var table = cloudStorageAccount.CreateCloudTableClient().GetTableReference(ServiceContext.TimeoutDataTableName);
+            var results = table.ExecuteQuery(new TableQuery()).ToList();
+            Assert.IsFalse(results.Any());
+        }
+
+        internal static void Perform_Storage_Cleanup()
+        {
+            Remove_All_Rows_For_Table(ServiceContext.TimeoutDataTableName);
+            Remove_All_Rows_For_Table(ServiceContext.TimeoutManagerDataTableName);
+            Remove_All_Blobs();
+        }
+
+        private static void Remove_All_Rows_For_Table(string tableName)
+        {
+            var cloudStorageAccount = CloudStorageAccount.Parse(AzurePersistenceTests.GetConnectionString());
+            var table = cloudStorageAccount.CreateCloudTableClient().GetTableReference(tableName);
+
+            var projectionQuery = new TableQuery<DynamicTableEntity>().Select(new[] { "Destination" });
+
+            // Define an entity resolver to work with the entity after retrieval.
+            EntityResolver<Tuple<string, string>> resolver = (pk, rk, ts, props, etag) => props.ContainsKey("Destination") ? new Tuple<string, string>(pk, rk) : null;
+
+            foreach (var tuple in table.ExecuteQuery(projectionQuery, resolver, null, null))
+            {
+                var tableEntity = new DynamicTableEntity(tuple.Item1, tuple.Item2) { ETag = "*" };
+                table.Execute(TableOperation.Delete(tableEntity));
+            }
+        }
+
+        private static void Remove_All_Blobs()
+        {
+            var cloudStorageAccount = CloudStorageAccount.Parse(AzurePersistenceTests.GetConnectionString());
+            var container = cloudStorageAccount.CreateCloudBlobClient().GetContainerReference("timeoutstate");
+            foreach (var blob in container.ListBlobs())
+            {
+                ((ICloudBlob)blob).Delete(DeleteSnapshotsOption.None, AccessCondition.GenerateEmptyCondition(), new BlobRequestOptions { RetryPolicy = new ExponentialRetry(TimeSpan.FromSeconds(15), 5) });
+
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence.Tests/Timeouts/When_removing_timeouts_from_the_storage.cs
+++ b/src/NServiceBus.AzureStoragePersistence.Tests/Timeouts/When_removing_timeouts_from_the_storage.cs
@@ -1,0 +1,207 @@
+﻿namespace NServiceBus.AzureStoragePersistence.Tests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Blob;
+    using Microsoft.WindowsAzure.Storage.RetryPolicies;
+    using Microsoft.WindowsAzure.Storage.Table;
+    using NServiceBus.Azure;
+    using NServiceBus.Config;
+    using NServiceBus.Timeout.Core;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureStoragePersistence")]
+    public class When_removing_timeouts_from_the_storage
+    {
+
+        [TestFixtureTearDown]
+        public void FixtureTearDown()
+        {
+            Test_Helper.Remove_All_Blobs();
+        }
+
+        [Test]
+        public void Should_return_correct_headers_when_timeout_is_TryRemoved()
+        {
+            var timeoutPersister = Test_Helper.Create_TimeoutPersister();
+
+            var timeout = Test_Helper.Generate_Timeout_With_Headers();
+            timeoutPersister.Add(timeout);
+
+            var timeouts = Test_Helper.Get_All_Timeouts(timeoutPersister);
+
+            Assert.True(timeouts.Count == 1);
+
+            TimeoutData timeoutData;
+            timeoutPersister.TryRemove(timeouts.First().Item1, out timeoutData);
+
+            CollectionAssert.AreEqual(new Dictionary<string, string> { { "Prop1", "1234" }, { "Prop2", "text" } }, timeoutData.Headers);
+
+            Test_Helper.Cleanup_Storage_Account(timeoutData, timeoutPersister);
+        }
+
+
+        [Test]
+        public void Should_return_orrect_headers_when_timeout_is_Peeked()
+        {
+            var timeoutPersister = Test_Helper.Create_TimeoutPersister();
+
+            var timeout = Test_Helper.Generate_Timeout_With_Headers();
+            timeoutPersister.Add(timeout);
+
+            var timeouts = Test_Helper.Get_All_Timeouts(timeoutPersister);
+
+            Assert.True(timeouts.Count == 1);
+
+            var timeoutId = timeouts.First().Item1;
+            var timeoutData = timeoutPersister.Peek(timeoutId);
+
+            CollectionAssert.AreEqual(new Dictionary<string, string> { { "Prop1", "1234" }, { "Prop2", "text" } }, timeoutData.Headers);
+
+            Test_Helper.Cleanup_Storage_Account(timeout, timeoutPersister);
+        }
+
+        [Test]
+        public void Peek_should_return_null_for_non_existing_timeout()
+        {
+            var timeoutPersister = Test_Helper.Create_TimeoutPersister();
+
+            var timeoutData = timeoutPersister.Peek("A2B34534324F3435A324234C");
+
+            Assert.IsNull(timeoutData);
+        }
+
+        [Test]
+        public void Should_remove_timeouts_by_id_using_old_interface()
+        {
+            var timeoutPersister = Test_Helper.Create_TimeoutPersister();
+            var timeout1 = Test_Helper.Generate_Timeout_With_Headers();
+            var timeout2 = Test_Helper.Generate_Timeout_With_Headers();
+            timeoutPersister.Add(timeout1);
+            timeoutPersister.Add(timeout2);
+
+            var timeouts = Test_Helper.Get_All_Timeouts(timeoutPersister);
+            Assert.IsTrue(timeouts.Count == 2);
+
+            foreach (var timeout in timeouts)
+            {
+                TimeoutData timeoutData;
+                timeoutPersister.TryRemove(timeout.Item1, out timeoutData);
+            }
+
+            Test_Helper.Assert_All_Timeouts_Have_Been_Removed(timeoutPersister);
+
+            Test_Helper.Cleanup_Storage_Account(timeout1, timeoutPersister, false);
+        }
+
+        [Test]
+        public void Should_remove_timeouts_by_id_and_return_true_using_new_interface()
+        {
+        }
+
+        [Test]
+        public void Should_remove_timeouts_by_sagaid()
+        {
+        }
+
+        [Test]
+        public void TryRemove_should_work_with_concurrent_operations()
+        {
+        }
+
+        static class Test_Helper
+        {
+            internal static TimeoutPersister Create_TimeoutPersister()
+            {
+                return new TimeoutPersister
+                {
+                    ConnectionString = AzurePersistenceTests.GetConnectionString(),
+                    PartitionKeyScope = new AzureTimeoutPersisterConfig().PartitionKeyScope
+                };
+            }
+
+
+            internal static TimeoutData Generate_Timeout_With_Headers()
+            {
+                return new TimeoutData
+                {
+                    Time = DateTime.UtcNow.AddYears(-1),
+                    Destination = new Address("timeouts", "some_azure_connection_string"),
+                    SagaId = Guid.NewGuid(),
+                    State = new byte[] { 1, 2, 3, 4 },
+                    Headers = new Dictionary<string, string>
+                    {
+                        {"Prop1", "1234"},
+                        {"Prop2", "text"}
+                    },
+                    OwningTimeoutManager = Configure.EndpointName
+                };
+            }
+
+            internal static List<Tuple<string, DateTime>> Get_All_Timeouts(TimeoutPersister persister)
+            {
+                DateTime nextRun;
+                var timeouts = persister.GetNextChunk(DateTime.Now.AddYears(-3), out nextRun).ToList();
+                return timeouts;
+            }
+
+            public static void Assert_All_Timeouts_Have_Been_Removed(TimeoutPersister timeoutPersister)
+            {
+                var cloudStorageAccount = CloudStorageAccount.Parse(timeoutPersister.ConnectionString);
+
+                var table = cloudStorageAccount.CreateCloudTableClient().GetTableReference(ServiceContext.TimeoutDataTableName);
+                var results = table.ExecuteQuery(new TableQuery()).ToList();
+                Assert.IsFalse(results.Any());
+            }
+
+            internal static void Cleanup_Storage_Account(TimeoutData timeoutDataToCleanup, TimeoutPersister timeoutPersister, bool deleteTimeoutDataRecords = true, bool deleteTimeDataManagerRecors = true)
+            {
+                var stateAddress = timeoutDataToCleanup.Id;
+                var cloudStorageAccount = CloudStorageAccount.Parse(timeoutPersister.ConnectionString);
+
+                if (deleteTimeoutDataRecords)
+                {
+                    // 1/3 - (state_address, empty)
+
+                    var table = cloudStorageAccount.CreateCloudTableClient().GetTableReference(ServiceContext.TimeoutDataTableName);
+                    var tableEntity = new DynamicTableEntity(stateAddress, string.Empty) { ETag = "*" };
+
+                    table.Execute(TableOperation.Delete(tableEntity));
+                    // 2/3 - (Date, state_address)
+                    tableEntity = new DynamicTableEntity(timeoutDataToCleanup.Time.ToString(timeoutPersister.PartitionKeyScope), stateAddress)
+                    {
+                        ETag = "*"
+                    };
+                    table.Execute(TableOperation.Delete(tableEntity));
+                    // 3/3 - (saga_id, state_address)
+                    tableEntity = new DynamicTableEntity(timeoutDataToCleanup.SagaId.ToString(), stateAddress)
+                    {
+                        ETag = "*"
+                    };
+                    table.Execute(TableOperation.Delete(tableEntity));
+                }
+
+                if (deleteTimeDataManagerRecors)
+                {
+                    // 1/1 - (unique_endpoint_name, empty)
+                    var table = cloudStorageAccount.CreateCloudTableClient().GetTableReference(ServiceContext.TimeoutManagerDataTableName);
+                    var tableEntity = new DynamicTableEntity(Configure.EndpointName + "_" + Environment.MachineName, string.Empty)
+                    {
+                        ETag = "*"
+                    };
+                    table.Execute(TableOperation.Delete(tableEntity));
+                }
+            }
+
+            public static void Remove_All_Blobs()
+            {
+                var cloudStorageAccount = CloudStorageAccount.Parse(AzurePersistenceTests.GetConnectionString());
+                var blob = cloudStorageAccount.CreateCloudBlobClient().GetContainerReference("timeoutstate");
+                blob.Delete(null, new BlobRequestOptions {RetryPolicy = new ExponentialRetry(TimeSpan.FromSeconds(15), 5)});
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence.Tests/Timeouts/When_timeout_is_added.cs
+++ b/src/NServiceBus.AzureStoragePersistence.Tests/Timeouts/When_timeout_is_added.cs
@@ -1,0 +1,27 @@
+﻿namespace NServiceBus.AzureStoragePersistence.Tests.Timeouts
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureStoragePersistence")]
+    public class When_timeout_is_added
+    {
+        [SetUp]
+        public void Perform_storage_cleanup()
+        {
+            Test_Helper.Perform_Storage_Cleanup();
+        }
+
+        [Test]
+        public void Should_retain_timeout_state()
+        {
+            var timeoutPersister = Test_Helper.Create_TimeoutPersister();
+            var timeout = Test_Helper.Generate_Timeout_With_Headers();
+            timeoutPersister.Add(timeout);
+
+            var peekedTimeout = timeoutPersister.Peek(timeout.Id);
+
+            Assert.AreEqual(timeout.State, peekedTimeout.State);
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence.Tests/ripple.dependencies.config
+++ b/src/NServiceBus.AzureStoragePersistence.Tests/ripple.dependencies.config
@@ -1,4 +1,5 @@
 Microsoft.Data.OData
+Microsoft.Data.Edm
 Microsoft.WindowsAzure.ConfigurationManager
 Microsoft.Data.Services.Client
 NServiceBus

--- a/src/NServiceBus.AzureStoragePersistence.Tests/ripple.dependencies.config
+++ b/src/NServiceBus.AzureStoragePersistence.Tests/ripple.dependencies.config
@@ -1,0 +1,9 @@
+Microsoft.Data.OData
+Microsoft.WindowsAzure.ConfigurationManager
+Microsoft.Data.Services.Client
+NServiceBus
+NServiceBus.Interfaces
+System.Spatial
+WindowsAzure.Storage
+NUnit
+RhinoMocks

--- a/src/NServiceBus.Hosting.Azure/DynamicHost/DynamicEndpointLoader.cs
+++ b/src/NServiceBus.Hosting.Azure/DynamicHost/DynamicEndpointLoader.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.WindowsAzure;
 
 namespace NServiceBus.Hosting
 {

--- a/src/NServiceBus.Hosting.Azure/DynamicHost/DynamicHostController.cs
+++ b/src/NServiceBus.Hosting.Azure/DynamicHost/DynamicHostController.cs
@@ -23,6 +23,7 @@ namespace NServiceBus.Hosting
         public DynamicHostController(IConfigureThisEndpoint specifier, string[] requestedProfiles, List<Type> defaultProfiles, string endpointName)
         {
             this.specifier = specifier;
+            // ReSharper disable once RedundantCast
             Configure.GetEndpointNameAction = (Func<string>)(() => endpointName);
 
             var assembliesToScan = new List<Assembly> {GetType().Assembly};

--- a/src/NServiceBus.Hosting.Azure/RoleHost/Entrypoint.cs
+++ b/src/NServiceBus.Hosting.Azure/RoleHost/Entrypoint.cs
@@ -47,6 +47,7 @@ namespace NServiceBus.Hosting.Azure
 
         static void CurrentDomainUnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
+            // ReSharper disable once RedundantToStringCall
             Trace.WriteLine("Unhandled exception occured: " + e.ExceptionObject.ToString());
         }
 

--- a/src/NServiceBus.Hosting.Azure/Roles/Handlers/TransportRoleHandler.cs
+++ b/src/NServiceBus.Hosting.Azure/Roles/Handlers/TransportRoleHandler.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.Hosting.Roles.Handlers
     using Hosting.Roles;
     using Transports;
     using Unicast.Config;
-    using Unicast.Transport;
 
 
     /// <summary>

--- a/src/NServiceBus.Hosting.Azure/Roles/UsingTransport.cs
+++ b/src/NServiceBus.Hosting.Azure/Roles/UsingTransport.cs
@@ -2,7 +2,6 @@ namespace NServiceBus
 {
     using Hosting.Roles;
     using Transports;
-    using Unicast.Transport;
 
     /// <summary>
     /// Role used to specify the desired transport to use


### PR DESCRIPTION
## Who's affected

 * Anyone using saga timeouts or deferred messages (e.g. `Bus.Defer(...)`) with Azure Storage Persistence

## Symptoms

When experiencing connectivity issues with the transport there's a chance that a due timeout/deferred message is lost. Therefore the message will never arrive.

## What to do if you are affected

We highly recommend to update to the latest patch versions of your NServiceBus and optional persistence and transport packages. For more details see issue https://github.com/Particular/NServiceBus/issues/2885

Connects to Particular/NServiceBus#2885