### PR TITLE
Hotfix-6.0.8 CircularBuffer throws exception

### DIFF
--- a/src/NServiceBus.Azure.QuickTests/NServiceBus.Azure.Tests.csproj
+++ b/src/NServiceBus.Azure.QuickTests/NServiceBus.Azure.Tests.csproj
@@ -86,6 +86,8 @@
     <Compile Include="Configuration\When_parsing_connectionstrings.cs" />
     <Compile Include="Configuration\When_using_the_azure_configuration_source.cs" />
     <Compile Include="Transports\ServiceBus\When_determining_subscription_names.cs" />
+    <Compile Include="Transports\ServiceBus\When_getting_items_from_circular_buffer.cs" />
+    <Compile Include="Transports\ServiceBus\When_putting_items_into_circular_buffer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Azure.Transports.WindowsAzureServiceBus\NServiceBus.Azure.Transports.WindowsAzureServiceBus.csproj">

--- a/src/NServiceBus.Azure.QuickTests/Transports/ServiceBus/When_getting_items_from_circular_buffer.cs
+++ b/src/NServiceBus.Azure.QuickTests/Transports/ServiceBus/When_getting_items_from_circular_buffer.cs
@@ -1,0 +1,36 @@
+namespace NServiceBus.AzureServiceBus.Tests
+{
+    using System.Threading.Tasks;
+    using NServiceBus.Azure.Transports.WindowsAzureServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureServiceBus")]
+    public class When_getting_items_from_circular_buffer
+    {
+        [Test]
+        public void Should_be_thread_safe()
+        {
+            var maxDegreeOfParallelism = 5;
+            var numberOfEntries = 2;
+
+            var buffer = new CircularBuffer<BufferEntry>(numberOfEntries);
+
+            Parallel.For(0, numberOfEntries, new ParallelOptions() { MaxDegreeOfParallelism = maxDegreeOfParallelism }, item =>
+            {
+                buffer.Put(new BufferEntry());
+            });
+
+            Parallel.For(0, 100000, new ParallelOptions() { MaxDegreeOfParallelism = maxDegreeOfParallelism }, item =>
+            {
+                buffer.Get();
+            });
+
+        }
+
+        class BufferEntry
+        {
+        }
+
+    }
+}

--- a/src/NServiceBus.Azure.QuickTests/Transports/ServiceBus/When_putting_items_into_circular_buffer.cs
+++ b/src/NServiceBus.Azure.QuickTests/Transports/ServiceBus/When_putting_items_into_circular_buffer.cs
@@ -1,0 +1,32 @@
+namespace NServiceBus.AzureServiceBus.Tests
+{
+    using System.Threading.Tasks;
+    using NServiceBus.Azure.Transports.WindowsAzureServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureServiceBus")]
+    public class When_putting_items_into_circular_buffer
+    {
+        [Test]
+        public void Should_be_thread_safe()
+        {
+            var maxDegreeOfParallelism = 5;
+            var numberOfEntries = 2;
+            var numberOfItems = 100000;
+
+            var buffer = new CircularBuffer<BufferEntry>(numberOfEntries, true); // overflow must be allowed
+
+            Parallel.For(0, numberOfItems, new ParallelOptions() { MaxDegreeOfParallelism = maxDegreeOfParallelism }, item =>
+            {
+                buffer.Put(new BufferEntry());
+            });
+
+        }
+
+        class BufferEntry
+        {
+        }
+
+    }
+}


### PR DESCRIPTION
## Who's affected

Anyone who's using Azure Service Bus transports and using `Bus.Send()` or `Bus.Publish()` in a very tight loop with multiple threads.

## Symptoms

Due to a calculation error that can happen with concurrent access an `IndexOutOfRangeException` exception can be thrown

---

Reported in GG: https://groups.google.com/forum/#!topic/particularsoftware/a1GigfXhI94

[`CircularBuffer.Get()`](https://github.com/Particular/NServiceBus.AzureServiceBus/blob/master/src/Transport/Creation/Clients/CircularBuffer.cs#L166) is not thread safe and may throw exception when used in concurrent mode

Repro:
```c#
Parallel.ForEach(hugeArray, new ParallelOptions() { MaxDegreeOfParallelism = 5 }, item =>
{
    Bus.Send(new SomethingCommand
    {
        Item = item
    });
});
```

Connects to Particular/NServiceBus.AzureServiceBus#59