### PR TITLE
Sagas with multiple starting messages should be correlated properly

### DIFF
--- a/src/NServiceBus.Azure.QuickTests/NServiceBus.Azure.Tests.csproj
+++ b/src/NServiceBus.Azure.QuickTests/NServiceBus.Azure.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="DataBus\ValidUntilV3BlobStorageDataBusTests.cs" />
     <Compile Include="DataBus\ValidUntilV4BlobStorageDataBusTests.cs" />
     <Compile Include="DataBus\When_using_AzureDataBusGuard.cs" />
+    <Compile Include="Sagas\LRUCacheTests.cs" />
     <Compile Include="Persisters\When_using_AzureTimeoutStorageGuard.cs" />
     <Compile Include="Persisters\When_using_AzureStorageSagaGuard.cs" />
     <Compile Include="Persisters\When_using_AzureSubscriptionStorageGuard.cs" />

--- a/src/NServiceBus.Azure.QuickTests/NServiceBus.Azure.Tests.csproj
+++ b/src/NServiceBus.Azure.QuickTests/NServiceBus.Azure.Tests.csproj
@@ -35,17 +35,17 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.OData.5.6.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    <Reference Include="Microsoft.Data.Services.Client">
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -78,9 +78,9 @@
     <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
+    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Services" />
@@ -94,10 +94,13 @@
     <Compile Include="DataBus\ValidUntilV3BlobStorageDataBusTests.cs" />
     <Compile Include="DataBus\ValidUntilV4BlobStorageDataBusTests.cs" />
     <Compile Include="DataBus\When_using_AzureDataBusGuard.cs" />
+    <Compile Include="Sagas\BaseAzureSagaPersisterTest.cs" />
     <Compile Include="Sagas\LRUCacheTests.cs" />
     <Compile Include="Persisters\When_using_AzureTimeoutStorageGuard.cs" />
     <Compile Include="Persisters\When_using_AzureStorageSagaGuard.cs" />
     <Compile Include="Persisters\When_using_AzureSubscriptionStorageGuard.cs" />
+    <Compile Include="Sagas\When_saga_duplicate_exists.cs" />
+    <Compile Include="Sagas\When_searched_by_property_without_existing_index.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Azure\NServiceBus.Azure.csproj">

--- a/src/NServiceBus.Azure.QuickTests/Sagas/BaseAzureSagaPersisterTest.cs
+++ b/src/NServiceBus.Azure.QuickTests/Sagas/BaseAzureSagaPersisterTest.cs
@@ -1,0 +1,78 @@
+﻿namespace NServiceBus.AzureStoragePersistence.Tests
+{
+    using System;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Table;
+    using Saga;
+    using SagaPersisters.Azure;
+
+    public abstract class BaseAzureSagaPersisterTest
+    {
+        protected readonly CloudStorageAccount cloudStorageAccount;
+        protected readonly AzureSagaPersister persister;
+        protected readonly CloudTable sagaTable;
+        protected readonly CloudTableClient tables;
+
+        protected BaseAzureSagaPersisterTest()
+        {
+            var connectionString = Environment.GetEnvironmentVariable("AzureStoragePersistence.ConnectionString");
+            cloudStorageAccount = CloudStorageAccount.Parse(connectionString);
+            persister = new AzureSagaPersister(cloudStorageAccount, true);
+            tables = cloudStorageAccount.CreateCloudTableClient();
+            sagaTable = tables.GetTableReference(typeof(TwoInstanceSagaState).Name);
+        }
+
+        protected void Clear()
+        {
+            foreach (var dte in sagaTable.ExecuteQuery(new TableQuery()))
+            {
+                sagaTable.Execute(TableOperation.Delete(dte));
+            }
+        }
+
+        protected void Insert(ITableEntity entity)
+        {
+            sagaTable.Execute(TableOperation.Insert(entity));
+        }
+
+        protected static TwoInstanceSagaStateEntity BuildState(string orderID, Guid id)
+        {
+            return new TwoInstanceSagaStateEntity
+            {
+                OrderId = orderID,
+                Id = id,
+                PartitionKey = id.ToString(),
+                RowKey = id.ToString()
+            };
+        }
+
+        public class TwoInstanceSagaState : IContainSagaData
+        {
+            [Unique]
+            public virtual string OrderId { get; set; }
+
+            public virtual Guid Id { get; set; }
+            public virtual string Originator { get; set; }
+            public virtual string OriginalMessageId { get; set; }
+        }
+
+        public class TwoInstanceSagaStateEntity : TableEntity
+        {
+            public virtual string OrderId { get; set; }
+            public virtual Guid Id { get; set; }
+            public virtual string Originator { get; set; }
+            public virtual string OriginalMessageId { get; set; }
+
+            public TwoInstanceSagaState ToState()
+            {
+                return new TwoInstanceSagaState
+                {
+                    Id = Id,
+                    OrderId = OrderId,
+                    OriginalMessageId = OriginalMessageId,
+                    Originator = Originator
+                };
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure.QuickTests/Sagas/LRUCacheTests.cs
+++ b/src/NServiceBus.Azure.QuickTests/Sagas/LRUCacheTests.cs
@@ -1,10 +1,25 @@
 ﻿namespace NServiceBus.AzureStoragePersistence.Tests
 {
-    using NServiceBus.SagaPersisters.Azure.SecondaryIndeces;
     using NUnit.Framework;
+    using SagaPersisters.Azure.SecondaryIndeces;
 
     public class LRUCacheTests
     {
+        private static void AssertValue(LRUCache<int, int> lruCache, int key, int expectedValue)
+        {
+            int value;
+            Assert.IsTrue(lruCache.TryGet(key, out value));
+            Assert.AreEqual(expectedValue, value);
+        }
+
+        private static void AssertNoValue(LRUCache<int, int> lruCache, int key)
+        {
+            int value;
+            var tryGet = lruCache.TryGet(key, out value);
+            Assert.AreEqual(false, tryGet);
+            Assert.AreEqual(default(int), value);
+        }
+
         public class When_cache_is_empty
         {
             private readonly LRUCache<int, int> Empty = new LRUCache<int, int>(0);
@@ -24,7 +39,6 @@
 
         public class When_cache_is_full
         {
-            private LRUCache<int, int> cache;
             private const int Key1 = 1;
             private const int Key2 = 2;
             private const int Key3 = 3;
@@ -32,6 +46,7 @@
             private const int Value11 = 111;
             private const int Value2 = 22;
             private const int Value3 = 32;
+            private LRUCache<int, int> cache;
 
             [SetUp]
             public void SetUp()
@@ -79,21 +94,6 @@
                 AssertValue(cache, Key1, Value1);
                 AssertValue(cache, Key3, Value3);
             }
-        }
-
-        private static void AssertValue(LRUCache<int, int> lruCache, int key, int expectedValue)
-        {
-            int value;
-            Assert.IsTrue(lruCache.TryGet(key, out value));
-            Assert.AreEqual(expectedValue, value);
-        }
-
-        private static void AssertNoValue(LRUCache<int, int> lruCache, int key)
-        {
-            int value;
-            var tryGet = lruCache.TryGet(key, out value);
-            Assert.AreEqual(false, tryGet);
-            Assert.AreEqual(default(int), value);
         }
     }
 }

--- a/src/NServiceBus.Azure.QuickTests/Sagas/LRUCacheTests.cs
+++ b/src/NServiceBus.Azure.QuickTests/Sagas/LRUCacheTests.cs
@@ -1,0 +1,99 @@
+﻿namespace NServiceBus.AzureStoragePersistence.Tests
+{
+    using NServiceBus.SagaPersisters.Azure.SecondaryIndeces;
+    using NUnit.Framework;
+
+    public class LRUCacheTests
+    {
+        public class When_cache_is_empty
+        {
+            private readonly LRUCache<int, int> Empty = new LRUCache<int, int>(0);
+
+            [Test]
+            public void Should_not_throw_on_remove()
+            {
+                Empty.Remove(1);
+            }
+
+            [Test]
+            public void Should_not_find_any_value()
+            {
+                AssertNoValue(Empty, 1);
+            }
+        }
+
+        public class When_cache_is_full
+        {
+            private LRUCache<int, int> cache;
+            private const int Key1 = 1;
+            private const int Key2 = 2;
+            private const int Key3 = 3;
+            private const int Value1 = 11;
+            private const int Value11 = 111;
+            private const int Value2 = 22;
+            private const int Value3 = 32;
+
+            [SetUp]
+            public void SetUp()
+            {
+                cache = new LRUCache<int, int>(2);
+                cache.Put(Key1, Value1);
+                cache.Put(Key2, Value2);
+            }
+
+            [Test]
+            public void Should_preserve_values()
+            {
+                AssertValue(cache, Key1, Value1);
+                AssertValue(cache, Key2, Value2);
+            }
+
+            [Test]
+            public void Should_add_new_value_removing_the_oldest()
+            {
+                cache.Put(Key3, Value3);
+
+                AssertNoValue(cache, Key1);
+                AssertValue(cache, Key2, Value2);
+                AssertValue(cache, Key3, Value3);
+            }
+
+            [Test]
+            public void Should_update_existing_value_reordering_lru_properly()
+            {
+                cache.Put(Key1, Value11);
+                cache.Put(Key3, Value3);
+
+                AssertNoValue(cache, Key2);
+                AssertValue(cache, Key1, Value11);
+                AssertValue(cache, Key3, Value3);
+            }
+
+            [Test]
+            public void Should_create_a_slot_when_removing()
+            {
+                cache.Remove(Key2);
+                cache.Put(Key3, Value3);
+
+                AssertNoValue(cache, Key2);
+                AssertValue(cache, Key1, Value1);
+                AssertValue(cache, Key3, Value3);
+            }
+        }
+
+        private static void AssertValue(LRUCache<int, int> lruCache, int key, int expectedValue)
+        {
+            int value;
+            Assert.IsTrue(lruCache.TryGet(key, out value));
+            Assert.AreEqual(expectedValue, value);
+        }
+
+        private static void AssertNoValue(LRUCache<int, int> lruCache, int key)
+        {
+            int value;
+            var tryGet = lruCache.TryGet(key, out value);
+            Assert.AreEqual(false, tryGet);
+            Assert.AreEqual(default(int), value);
+        }
+    }
+}

--- a/src/NServiceBus.Azure.QuickTests/Sagas/When_saga_duplicate_exists.cs
+++ b/src/NServiceBus.Azure.QuickTests/Sagas/When_saga_duplicate_exists.cs
@@ -1,0 +1,32 @@
+namespace NServiceBus.AzureStoragePersistence.Tests
+{
+    using System;
+    using NUnit.Framework;
+    using Saga;
+
+    [Explicit]
+    public class When_saga_duplicate_exists : BaseAzureSagaPersisterTest
+    {
+        static readonly Guid ID1 = new Guid("E109827C-C9E2-48C0-91D9-D7D4C1ED3B51");
+        static readonly Guid ID2 = new Guid("89ECE262-9D76-4D62-A0DA-243AA59663D8");
+
+        [Test]
+        public void Should_throw_exception()
+        {
+            Clear();
+
+            var orderID = "order_id";
+            var s1 = BuildState(orderID, ID1);
+            var s2 = BuildState(orderID, ID2);
+
+            Insert(s1);
+            Insert(s2);
+
+            Assert.Throws(Is.AssignableTo<Exception>(), () =>
+            {
+                var state = ((ISagaPersister)persister).Get<TwoInstanceSagaState>("OrderId", orderID);
+                persister.Update(state);
+            });
+        }
+    }
+}

--- a/src/NServiceBus.Azure.QuickTests/Sagas/When_saga_duplicate_exists.cs
+++ b/src/NServiceBus.Azure.QuickTests/Sagas/When_saga_duplicate_exists.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.AzureStoragePersistence.Tests
     using System;
     using NUnit.Framework;
     using Saga;
+    using SagaPersisters.Azure;
 
     [Explicit]
     public class When_saga_duplicate_exists : BaseAzureSagaPersisterTest
@@ -22,9 +23,9 @@ namespace NServiceBus.AzureStoragePersistence.Tests
             Insert(s1);
             Insert(s2);
 
-            Assert.Throws(Is.AssignableTo<Exception>(), () =>
+            Assert.Throws(Is.AssignableTo<DuplicatedSagaFoundException>(), () =>
             {
-                var state = ((ISagaPersister)persister).Get<TwoInstanceSagaState>("OrderId", orderID);
+                var state = ((ISagaPersister) persister).Get<TwoInstanceSagaState>("OrderId", orderID);
                 persister.Update(state);
             });
         }

--- a/src/NServiceBus.Azure.QuickTests/Sagas/When_searched_by_property_without_existing_index.cs
+++ b/src/NServiceBus.Azure.QuickTests/Sagas/When_searched_by_property_without_existing_index.cs
@@ -1,0 +1,33 @@
+namespace NServiceBus.AzureStoragePersistence.Tests
+{
+    using System;
+    using NUnit.Framework;
+    using Saga;
+
+    [Explicit]
+    public class When_searched_by_property_without_existing_index : BaseAzureSagaPersisterTest
+    {
+        static readonly Guid ID1 = new Guid("46E0E0B1-B4FE-476A-8C25-0175424601CD");
+        static readonly Guid ID2 = new Guid("0A63BB08-8951-4DF1-A149-121531C05F34");
+
+        [Test]
+        public void Should_create_index()
+        {
+            Clear();
+
+            const string orderID = "order_id_1";
+
+            var s1 = BuildState(orderID, ID1);
+            var s2 = BuildState("order_id_2", ID2);
+
+            Insert(s1);
+            Insert(s2);
+
+            var state = ((ISagaPersister) persister).Get<TwoInstanceSagaState>("OrderId", orderID);
+
+            Assert.NotNull(state);
+            Assert.AreEqual(ID1, state.Id);
+            Assert.AreEqual(orderID, state.OrderId);
+        }
+    }
+}

--- a/src/NServiceBus.Azure.QuickTests/packages.config
+++ b/src/NServiceBus.Azure.QuickTests/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
   <package id="NServiceBus" version="5.2.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="WindowsAzure.ServiceBus" version="2.5.4" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/NServiceBus.Azure/NServiceBus.Azure.csproj
+++ b/src/NServiceBus.Azure/NServiceBus.Azure.csproj
@@ -114,6 +114,7 @@
     <Compile Include="SagaPersisters\AzureStorageSagaGuard.cs" />
     <Compile Include="SagaPersisters\AzureStorageSagaDefaults.cs" />
     <Compile Include="SagaPersisters\Azure\AzureStorageSagaPersistence.cs" />
+    <Compile Include="SagaPersisters\Azure\Class1.cs" />
     <Compile Include="SagaPersisters\Azure\RetryNeededException.cs" />
     <Compile Include="SagaPersisters\Azure\SecondaryIndeces\LRUCache.cs" />
     <Compile Include="SagaPersisters\Azure\SecondaryIndeces\PartitionRowKeyTuple.cs" />

--- a/src/NServiceBus.Azure/NServiceBus.Azure.csproj
+++ b/src/NServiceBus.Azure/NServiceBus.Azure.csproj
@@ -114,6 +114,12 @@
     <Compile Include="SagaPersisters\AzureStorageSagaGuard.cs" />
     <Compile Include="SagaPersisters\AzureStorageSagaDefaults.cs" />
     <Compile Include="SagaPersisters\Azure\AzureStorageSagaPersistence.cs" />
+    <Compile Include="SagaPersisters\Azure\RetryNeededException.cs" />
+    <Compile Include="SagaPersisters\Azure\SecondaryIndeces\LRUCache.cs" />
+    <Compile Include="SagaPersisters\Azure\SecondaryIndeces\PartitionRowKeyTuple.cs" />
+    <Compile Include="SagaPersisters\Azure\SecondaryIndeces\SagaDataSerializer.cs" />
+    <Compile Include="SagaPersisters\Azure\SecondaryIndeces\SecondaryIndexPersister.cs" />
+    <Compile Include="SagaPersisters\Azure\SecondaryIndeces\SecondaryIndexTableEntity.cs" />
     <Compile Include="SagaPersisters\ConfigureAzureSagaStorage.cs" />
     <Compile Include="Subscriptions\AzureSubscriptionStorageGuard.cs" />
     <Compile Include="Subscriptions\Azure\AzureStorageSubscriptionPersistence.cs" />
@@ -149,6 +155,7 @@
     <Compile Include="Subscriptions\Azure\Subscription.cs" />
     <Compile Include="Subscriptions\Azure\SubscriptionServiceContext.cs" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/NServiceBus.Azure/SagaPersisters/Azure/AzureSagaPersister.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/Azure/AzureSagaPersister.cs
@@ -3,12 +3,12 @@
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Net;
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Table;
     using NServiceBus.Azure;
+    using NServiceBus.SagaPersisters.Azure.SecondaryIndeces;
     using Saga;
 
     /// <summary>
@@ -18,9 +18,11 @@
     {
         readonly bool autoUpdateSchema;
         readonly CloudTableClient client;
+        readonly SecondaryIndexPersister secondaryIndeces;
+
         static readonly ConcurrentDictionary<string, bool> tableCreated = new ConcurrentDictionary<string, bool>();
         static readonly ConditionalWeakTable<object, string> etags = new ConditionalWeakTable<object, string>();
-        
+
         /// <summary>
         /// 
         /// </summary>
@@ -30,6 +32,7 @@
         {
             this.autoUpdateSchema = autoUpdateSchema;
             client = account.CreateCloudTableClient();
+            secondaryIndeces = new SecondaryIndexPersister(GetTable, ScanForSaga, Persist);
         }
 
         /// <summary>
@@ -39,6 +42,7 @@
         /// <param name="saga">the saga entity that will be saved.</param>
         public void Save(IContainSagaData saga)
         {
+            secondaryIndeces.Insert(saga);
             Persist(saga);
         }
 
@@ -73,7 +77,6 @@
             return entity;
         }
 
-
         DictionaryTableEntity GetDictionaryTableEntity(string sagaId, Type entityType)
         {
             var tableName = entityType.Name;
@@ -87,38 +90,13 @@
 
         T ISagaPersister.Get<T>(string property, object value)
         {
-            var type = typeof(T);
-            var tableEntity = GetDictionaryTableEntity(type, property, value);
-            var entity = (T) ToEntity(type, tableEntity);
-
-            if (!Equals(entity, default(T)))
+            var sagaId = secondaryIndeces.FindPossiblyCreatingIndexEntry<T>(property, value);
+            if (sagaId != null)
             {
-                etags.Add(entity, tableEntity.ETag);
+                return Get<T>(sagaId.Value);
             }
 
-            try
-            {
-                return entity;
-            }
-            catch (WebException ex)
-            {
-                // can occur when table has not yet been created, but already looking for absence of instance
-                if (ex.Status == WebExceptionStatus.ProtocolError && ex.Response != null)
-                {
-                    var response = (HttpWebResponse) ex.Response;
-                    if (response.StatusCode == HttpStatusCode.NotFound)
-                    {
-                        return default(T);
-                    }
-                }
-
-                throw;
-            }
-            catch (StorageException)
-            {
-                // can occur when table has not yet been created, but already looking for absence of instance
-                return default(T);
-            }
+            return default(T);
         }
 
         DictionaryTableEntity GetDictionaryTableEntity(Type type, string property, object value)
@@ -132,35 +110,35 @@
 
             if (propertyInfo.PropertyType == typeof(byte[]))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBinary(property, QueryComparisons.Equal, (byte[]) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBinary(property, QueryComparisons.Equal, (byte[])value));
             }
             else if (propertyInfo.PropertyType == typeof(bool))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBool(property, QueryComparisons.Equal, (bool) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBool(property, QueryComparisons.Equal, (bool)value));
             }
             else if (propertyInfo.PropertyType == typeof(DateTime))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDate(property, QueryComparisons.Equal, (DateTime) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDate(property, QueryComparisons.Equal, (DateTime)value));
             }
             else if (propertyInfo.PropertyType == typeof(Guid))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForGuid(property, QueryComparisons.Equal, (Guid) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForGuid(property, QueryComparisons.Equal, (Guid)value));
             }
             else if (propertyInfo.PropertyType == typeof(Int32))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForInt(property, QueryComparisons.Equal, (int) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForInt(property, QueryComparisons.Equal, (int)value));
             }
             else if (propertyInfo.PropertyType == typeof(Int64))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForLong(property, QueryComparisons.Equal, (long) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForLong(property, QueryComparisons.Equal, (long)value));
             }
             else if (propertyInfo.PropertyType == typeof(Double))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDouble(property, QueryComparisons.Equal, (double) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDouble(property, QueryComparisons.Equal, (double)value));
             }
             else if (propertyInfo.PropertyType == typeof(string))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterCondition(property, QueryComparisons.Equal, (string) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterCondition(property, QueryComparisons.Equal, (string)value));
             }
             else
             {
@@ -196,21 +174,38 @@
         void Persist(IContainSagaData saga)
         {
             var type = saga.GetType();
-            var tableName = type.Name;
+            var table = GetTable(type);
+
+            var partitionKey = saga.Id.ToString();
+
+            var batch = new TableBatchOperation();
+
+            AddObjectToBatch(batch, saga, partitionKey);
+
+            table.ExecuteBatch(batch);
+        }
+
+        private CloudTable GetTable(Type sagaType)
+        {
+            var tableName = sagaType.Name;
             var table = client.GetTableReference(tableName);
             if (autoUpdateSchema && !tableCreated.ContainsKey(tableName))
             {
                 table.CreateIfNotExists();
                 tableCreated[tableName] = true;
             }
+            return table;
+        }
 
-            var partitionKey = saga.Id.ToString();
-                
-            var batch = new TableBatchOperation();
+        private Guid? ScanForSaga(Type sagatype, string propertyName, object propertyValue)
+        {
+            var entity = GetDictionaryTableEntity(sagatype, propertyName, propertyValue);
+            if (entity == null)
+            {
+                return null;
+            }
 
-            AddObjectToBatch(batch, saga, partitionKey);
-
-            table.ExecuteBatch(batch);
+            return Guid.ParseExact(entity.PartitionKey, "D");
         }
 
         void AddObjectToBatch(TableBatchOperation batch, object entity, string partitionKey, string rowkey = "")
@@ -221,39 +216,44 @@
             string etag;
             var update = etags.TryGetValue(entity, out etag);
 
-            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var properties = SelectPropertiesToPersist(type);
 
-            var toPersist = ToDictionaryTableEntity(entity, new DictionaryTableEntity { PartitionKey = partitionKey, RowKey = rowkey, ETag = etag}, properties);
+            var toPersist = ToDictionaryTableEntity(entity, new DictionaryTableEntity { PartitionKey = partitionKey, RowKey = rowkey, ETag = etag }, properties);
 
             //no longer using InsertOrReplace as it ignores concurrency checks
             batch.Add(update ? TableOperation.Replace(toPersist) : TableOperation.Insert(toPersist));
+        }
+
+        internal static PropertyInfo[] SelectPropertiesToPersist(Type sagaType)
+        {
+            return sagaType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         }
 
         DictionaryTableEntity ToDictionaryTableEntity(object entity, DictionaryTableEntity toPersist, IEnumerable<PropertyInfo> properties)
         {
             foreach (var propertyInfo in properties)
             {
-                if (propertyInfo.PropertyType == typeof (byte[]))
+                if (propertyInfo.PropertyType == typeof(byte[]))
                 {
-                    toPersist[propertyInfo.Name]= new EntityProperty((byte[]) propertyInfo.GetValue(entity, null)) ;
+                    toPersist[propertyInfo.Name] = new EntityProperty((byte[])propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (bool))
+                else if (propertyInfo.PropertyType == typeof(bool))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((bool)propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (DateTime))
+                else if (propertyInfo.PropertyType == typeof(DateTime))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((DateTime)propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (Guid))
+                else if (propertyInfo.PropertyType == typeof(Guid))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((Guid)propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (Int32))
+                else if (propertyInfo.PropertyType == typeof(Int32))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((Int32)propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (Int64))
+                else if (propertyInfo.PropertyType == typeof(Int64))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((Int64)propertyInfo.GetValue(entity, null));
                 }
@@ -261,7 +261,7 @@
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((Double)propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (string))
+                else if (propertyInfo.PropertyType == typeof(string))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((string)propertyInfo.GetValue(entity, null));
                 }
@@ -333,6 +333,6 @@
             return toCreate;
         }
     }
-    
-  
+
+
 }

--- a/src/NServiceBus.Azure/SagaPersisters/Azure/Class1.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/Azure/Class1.cs
@@ -1,0 +1,19 @@
+﻿namespace NServiceBus.SagaPersisters.Azure
+{
+    using System;
+
+    public class DuplicatedSagaFoundException : Exception
+    {
+        public DuplicatedSagaFoundException(Type sagaType, string propertyName, params Guid[] identifiers)
+            : base($"Sagas of type {sagaType.Name} with the following identifiers '{string.Join("', '", identifiers)}' are considered duplicates because of the violation of the Unique property {propertyName}.")
+        {
+            SagaType = sagaType;
+            PropertyName = propertyName;
+            Identifiers = identifiers;
+        }
+
+        public Type SagaType { get; }
+        public Guid[] Identifiers { get; }
+        public string PropertyName { get; }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/Azure/RetryNeededException.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/Azure/RetryNeededException.cs
@@ -1,0 +1,11 @@
+﻿namespace NServiceBus.SagaPersisters.Azure
+{
+    using System;
+
+    public class RetryNeededException : Exception
+    {
+        public RetryNeededException() : base("This operation requires a retry as it wasn't possible to successfully process it now.")
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/LRUCache.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/LRUCache.cs
@@ -1,0 +1,93 @@
+namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System.Collections.Generic;
+
+    public sealed class LRUCache<TKey, TValue>
+    {
+        readonly LinkedList<Item> lru = new LinkedList<Item>();
+        readonly Dictionary<TKey, LinkedListNode<Item>> items = new Dictionary<TKey, LinkedListNode<Item>>();
+
+        readonly int capacity;
+        readonly object @lock = new object();
+
+        private class Item
+        {
+            public TKey Key;
+            public TValue Value;
+        }
+
+        public LRUCache(int capacity)
+        {
+            this.capacity = capacity;
+        }
+
+        public bool TryGet(TKey key, out TValue value)
+        {
+            lock (@lock)
+            {
+                LinkedListNode<Item> node;
+                if (items.TryGetValue(key, out node))
+                {
+                    lru.Remove(node);
+                    lru.AddLast(node);
+                    value = node.Value.Value;
+                    return true;
+                }
+
+                value = default(TValue);
+                return false;
+            }
+        }
+
+        public void Put(TKey key, TValue value)
+        {
+            lock (@lock)
+            {
+                LinkedListNode<Item> node;
+                if (items.TryGetValue(key, out node) == false)
+                {
+                    node = new LinkedListNode<Item>(
+                        new Item
+                        {
+                            Key = key,
+                            Value = value
+                        });
+                    items.Add(key, node);
+
+                    TrimOneIfNeeded();
+                }
+                else
+                {
+                    // just update the value
+                    node.Value.Value = value;
+                    lru.Remove(node);
+                }
+
+                lru.AddLast(node);
+            }
+        }
+
+        public void Remove(TKey key)
+        {
+            lock (@lock)
+            {
+                LinkedListNode<Item> node;
+                if (items.TryGetValue(key, out node))
+                {
+                    lru.Remove(node);
+                    items.Remove(key);
+                }
+            }
+        }
+
+        private void TrimOneIfNeeded()
+        {
+            if (items.Count > 0 && items.Count > capacity)
+            {
+                var node = lru.First;
+                lru.Remove(node);
+                items.Remove(node.Value.Key);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/PartitionRowKeyTuple.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/PartitionRowKeyTuple.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using Microsoft.WindowsAzure.Storage.Table;
+
+    public sealed class PartitionRowKeyTuple
+    {
+        public string PartitionKey { get; }
+        public string RowKey { get; }
+
+        public PartitionRowKeyTuple(string partitionKey, string rowKey)
+        {
+            PartitionKey = partitionKey;
+            RowKey = rowKey;
+        }
+
+        public void Apply(ITableEntity entity)
+        {
+            entity.PartitionKey = PartitionKey;
+            entity.RowKey = RowKey;
+        }
+
+        private bool Equals(PartitionRowKeyTuple other)
+        {
+            return string.Equals(PartitionKey, other.PartitionKey) && string.Equals(RowKey, other.RowKey);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+            return Equals((PartitionRowKeyTuple) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((PartitionKey?.GetHashCode() ?? 0)*397) ^ (RowKey?.GetHashCode() ?? 0);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SagaDataSerializer.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SagaDataSerializer.cs
@@ -1,0 +1,71 @@
+namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Linq;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
+    using NServiceBus.Saga;
+
+    /// <summary>
+    /// A helper saga data serializer for internal purposes
+    /// </summary>
+    internal class SagaDataSerializer
+    {
+        public static byte[] SerializeSagaData<TSagaData>(TSagaData sagaData) where TSagaData : IContainSagaData
+        {
+            var serializer = new JsonSerializer
+            {
+                ContractResolver = new SagaOnlyPropertiesDataContractResolver()
+            };
+
+            using (var ms = new MemoryStream())
+            {
+                using (var zipped = new GZipStream(ms, CompressionMode.Compress))
+                {
+                    using (var sw = new StreamWriter(zipped))
+                    {
+                        serializer.Serialize(sw, sagaData);
+                        sw.Flush();
+                    }
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        public static IContainSagaData DeserializeSagaData(Type sagaType, byte[] value)
+        {
+            var serializer = new JsonSerializer
+            {
+                ContractResolver = new SagaOnlyPropertiesDataContractResolver()
+            };
+
+            using (var ms = new MemoryStream(value))
+            {
+                using (var zipped = new GZipStream(ms, CompressionMode.Decompress))
+                {
+                    using (var sr = new StreamReader(zipped))
+                    {
+                        return (IContainSagaData)serializer.Deserialize(sr, sagaType);
+                    }
+                }
+            }
+        }
+
+        private class SagaOnlyPropertiesDataContractResolver : DefaultContractResolver
+        {
+            public SagaOnlyPropertiesDataContractResolver() : base(true) // for performance
+            {
+            }
+
+            protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+            {
+                var properties = new HashSet<string>(AzureSagaPersister.SelectPropertiesToPersist(type).Select(pi => pi.Name));
+                return base.CreateProperties(type, memberSerialization).Where(p => properties.Contains(p.PropertyName)).ToArray();
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
@@ -1,0 +1,215 @@
+﻿namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.IO;
+    using System.Linq.Expressions;
+    using System.Net;
+    using System.Reflection;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Table;
+    using Newtonsoft.Json;
+    using NServiceBus.Saga;
+
+    public class SecondaryIndexPersister
+    {
+        readonly Func<Type, CloudTable> getTableForSaga;
+        readonly ScanForSaga scanner;
+        readonly Action<IContainSagaData> persist;
+        
+        const int LRUCapacity = 1000;
+        readonly LRUCache<PartitionRowKeyTuple, Guid> cache = new LRUCache<PartitionRowKeyTuple, Guid>(LRUCapacity);
+
+        public SecondaryIndexPersister(Func<Type, CloudTable> getTableForSaga, ScanForSaga scanner, Action<IContainSagaData> persist)
+        {
+            this.getTableForSaga = getTableForSaga;
+            this.scanner = scanner;
+            this.persist = persist;
+        }
+
+        public delegate Guid? ScanForSaga(Type sagaType, string propertyName, object propertyValue);
+
+        public void Insert(IContainSagaData sagaData)
+        {
+            var sagaType = sagaData.GetType();
+            var table = getTableForSaga(sagaType);
+            var ix = IndexDefintion.Get(sagaType);
+            if (ix == null)
+            {
+                return;
+            }
+
+            var propertyValue = ix.Accessor(sagaData);
+            var key = ix.BuildTableKey(propertyValue);
+
+            var entity = new SecondaryIndexTableEntity
+            {
+                SagaId = sagaData.Id,
+                InitialSagaData = SagaDataSerializer.SerializeSagaData(sagaData),
+                PartitionKey = key.PartitionKey,
+                RowKey = key.RowKey
+            };
+
+            // the insert plan is following:
+            // 1) try insert the 2nd index row
+            // 2) if it fails, another worker has done it
+            // 3) ensure that the primary is stored, throwing an exception afterwards in any way
+
+            try
+            {
+                table.Execute(TableOperation.Insert(entity));
+            }
+            catch (StorageException ex)
+            {
+                var indexRowAlreadyExists = IsConflict(ex);
+                if (indexRowAlreadyExists)
+                {
+                    var indexRow = table.Execute(TableOperation.Retrieve<SecondaryIndexTableEntity>(key.PartitionKey, key.RowKey)).Result as SecondaryIndexTableEntity;
+                    var data = indexRow?.InitialSagaData;
+                    if (data != null)
+                    {
+                        var deserializeSagaData = SagaDataSerializer.DeserializeSagaData(sagaType, data);
+
+                        // saga hasn't been saved under primary key. Try to store it
+                        try
+                        {
+                            persist(deserializeSagaData);
+                        }
+                        catch (StorageException e)
+                        {
+                            if (IsConflict(e))
+                            {
+                                // swallow ex as another worker created the primary under this key
+                            }
+                        }
+                    }
+
+                    throw new RetryNeededException();
+                }
+
+                throw;
+            }
+        }
+
+        public Guid? FindPossiblyCreatingIndexEntry<TSagaData>(string propertyName, object propertyValue)
+            where TSagaData : IContainSagaData
+        {
+            var sagaType = typeof(TSagaData);
+            var ix = IndexDefintion.Get(sagaType);
+            if (ix == null)
+            {
+                throw new ArgumentException($"Saga {typeof(TSagaData)} has no correlation properties. Ensure that your saga is correlated by this property and only then, mark it with `Unique` attribute.");
+            }
+
+            ix.ValidateProperty(propertyName);
+
+            var key = ix.BuildTableKey(propertyValue);
+
+            Guid guid;
+            if (cache.TryGet(key, out guid))
+            {
+                return guid;
+            }
+
+            var table = getTableForSaga(sagaType);
+            var secondaryIndexEntry = table.Execute(TableOperation.Retrieve<SecondaryIndexTableEntity>(key.PartitionKey, key.RowKey)).Result as SecondaryIndexTableEntity;
+            if (secondaryIndexEntry != null)
+            {
+                cache.Put(key, secondaryIndexEntry.SagaId);
+                return secondaryIndexEntry.SagaId;
+            }
+
+            var sagaId = scanner(sagaType, propertyName, propertyValue);
+            if (sagaId == null)
+            {
+                return null;
+            }
+
+            var entity = new SecondaryIndexTableEntity();
+            key.Apply(entity);
+            entity.SagaId = sagaId.Value;
+
+            try
+            {
+                table.Execute(TableOperation.Insert(entity));
+            }
+            catch (StorageException)
+            {
+                throw new RetryNeededException();
+            }
+
+            cache.Put(key, sagaId.Value);
+            return sagaId;
+        }
+
+        private static bool IsConflict(StorageException ex)
+        {
+            return ex.RequestInformation.HttpStatusCode == (int) HttpStatusCode.Conflict;
+        }
+
+        private class IndexDefintion
+        {
+            static readonly ConcurrentDictionary<Type, object> sagaToIndex = new ConcurrentDictionary<Type, object>();
+            static readonly object NullValue = new object();
+
+            static readonly ParameterExpression ObjectParameter = Expression.Parameter(typeof(object));
+
+            readonly string sagaTypeName;
+            readonly string propertyName;
+
+            public Func<object, object> Accessor { get; }
+
+            private IndexDefintion(Type sagaType, PropertyInfo pi)
+            {
+                sagaTypeName = sagaType.FullName;
+                propertyName = pi.Name;
+                Accessor = Expression.Lambda<Func<object, object>>(Expression.Convert(Expression.MakeMemberAccess(Expression.Convert(ObjectParameter, sagaType), pi), typeof(object)), ObjectParameter).Compile();
+            }
+
+            public static IndexDefintion Get(Type sagaType)
+            {
+                var index = sagaToIndex.GetOrAdd(sagaType, type =>
+                {
+                    var pi = UniqueAttribute.GetUniqueProperty(sagaType);
+                    if (pi == null)
+                    {
+                        return NullValue;
+                    }
+
+                    return new IndexDefintion(sagaType, pi);
+                });
+
+                if (ReferenceEquals(index, NullValue))
+                {
+                    return null;
+                }
+
+                return (IndexDefintion) index;
+            }
+
+            public void ValidateProperty(string propertyName)
+            {
+                if (this.propertyName != propertyName)
+                {
+                    throw new ArgumentException($"The following saga '{sagaTypeName} is not indexed by '{propertyName}'. The only secondary index is defined for '{this.propertyName}'. " +
+                                                $"Ensure that the saga is correlated properly.");
+                }
+            }
+
+            public PartitionRowKeyTuple BuildTableKey(object propertyValue)
+            {
+                return new PartitionRowKeyTuple($"Index_{sagaTypeName}", $"{propertyName}_{Serialize(propertyValue)}");
+            }
+
+            private static string Serialize(object propertyValue)
+            {
+                using (var sw = new StringWriter())
+                {
+                    new JsonSerializer().Serialize(sw, propertyValue);
+                    sw.Flush();
+                    return sw.ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
@@ -197,7 +197,7 @@
 
             public PartitionRowKeyTuple BuildTableKey(object propertyValue)
             {
-                return new PartitionRowKeyTuple($"Index_{sagaTypeName}", $"{propertyName}_{Serialize(propertyValue)}");
+                return new PartitionRowKeyTuple($"Index_{sagaTypeName}_{propertyName}_{Serialize(propertyValue)}", "");
             }
 
             private static string Serialize(object propertyValue)

--- a/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexTableEntity.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexTableEntity.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System;
+    using Microsoft.WindowsAzure.Storage.Table;
+
+    /// <summary>
+    /// An entity holding information about the secondary index.
+    /// </summary>
+    public class SecondaryIndexTableEntity : TableEntity
+    {
+        public Guid SagaId { get; set; }
+
+        public byte[] InitialSagaData { get; set; }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/RetryNeededException.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/RetryNeededException.cs
@@ -1,0 +1,11 @@
+﻿namespace NServiceBus.SagaPersisters.Azure
+{
+    using System;
+
+    public class RetryNeededException : Exception
+    {
+        public RetryNeededException() : base("This operation requires a retry as it wasn't possible to successfully process it now.")
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/SecondaryIndeces/LRUCache.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/SecondaryIndeces/LRUCache.cs
@@ -1,0 +1,93 @@
+namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System.Collections.Generic;
+
+    public sealed class LRUCache<TKey, TValue>
+    {
+        readonly LinkedList<Item> lru = new LinkedList<Item>();
+        readonly Dictionary<TKey, LinkedListNode<Item>> items = new Dictionary<TKey, LinkedListNode<Item>>();
+
+        readonly int capacity;
+        readonly object @lock = new object();
+
+        private class Item
+        {
+            public TKey Key;
+            public TValue Value;
+        }
+
+        public LRUCache(int capacity)
+        {
+            this.capacity = capacity;
+        }
+
+        public bool TryGet(TKey key, out TValue value)
+        {
+            lock (@lock)
+            {
+                LinkedListNode<Item> node;
+                if (items.TryGetValue(key, out node))
+                {
+                    lru.Remove(node);
+                    lru.AddLast(node);
+                    value = node.Value.Value;
+                    return true;
+                }
+
+                value = default(TValue);
+                return false;
+            }
+        }
+
+        public void Put(TKey key, TValue value)
+        {
+            lock (@lock)
+            {
+                LinkedListNode<Item> node;
+                if (items.TryGetValue(key, out node) == false)
+                {
+                    node = new LinkedListNode<Item>(
+                        new Item
+                        {
+                            Key = key,
+                            Value = value
+                        });
+                    items.Add(key, node);
+
+                    TrimOneIfNeeded();
+                }
+                else
+                {
+                    // just update the value
+                    node.Value.Value = value;
+                    lru.Remove(node);
+                }
+
+                lru.AddLast(node);
+            }
+        }
+
+        public void Remove(TKey key)
+        {
+            lock (@lock)
+            {
+                LinkedListNode<Item> node;
+                if (items.TryGetValue(key, out node))
+                {
+                    lru.Remove(node);
+                    items.Remove(key);
+                }
+            }
+        }
+
+        private void TrimOneIfNeeded()
+        {
+            if (items.Count > 0 && items.Count > capacity)
+            {
+                var node = lru.First;
+                lru.Remove(node);
+                items.Remove(node.Value.Key);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/SecondaryIndeces/PartitionRowKeyTuple.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/SecondaryIndeces/PartitionRowKeyTuple.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using Microsoft.WindowsAzure.Storage.Table;
+
+    public sealed class PartitionRowKeyTuple
+    {
+        public string PartitionKey { get; }
+        public string RowKey { get; }
+
+        public PartitionRowKeyTuple(string partitionKey, string rowKey)
+        {
+            PartitionKey = partitionKey;
+            RowKey = rowKey;
+        }
+
+        public void Apply(ITableEntity entity)
+        {
+            entity.PartitionKey = PartitionKey;
+            entity.RowKey = RowKey;
+        }
+
+        private bool Equals(PartitionRowKeyTuple other)
+        {
+            return string.Equals(PartitionKey, other.PartitionKey) && string.Equals(RowKey, other.RowKey);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+            return Equals((PartitionRowKeyTuple) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((PartitionKey?.GetHashCode() ?? 0)*397) ^ (RowKey?.GetHashCode() ?? 0);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/SecondaryIndeces/SagaDataSerializer.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/SecondaryIndeces/SagaDataSerializer.cs
@@ -1,0 +1,71 @@
+namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Linq;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
+    using NServiceBus.Saga;
+
+    /// <summary>
+    /// A helper saga data serializer for internal purposes
+    /// </summary>
+    internal class SagaDataSerializer
+    {
+        public static byte[] SerializeSagaData<TSagaData>(TSagaData sagaData) where TSagaData : IContainSagaData
+        {
+            var serializer = new JsonSerializer
+            {
+                ContractResolver = new SagaOnlyPropertiesDataContractResolver()
+            };
+
+            using (var ms = new MemoryStream())
+            {
+                using (var zipped = new GZipStream(ms, CompressionMode.Compress))
+                {
+                    using (var sw = new StreamWriter(zipped))
+                    {
+                        serializer.Serialize(sw, sagaData);
+                        sw.Flush();
+                    }
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        public static IContainSagaData DeserializeSagaData(Type sagaType, byte[] value)
+        {
+            var serializer = new JsonSerializer
+            {
+                ContractResolver = new SagaOnlyPropertiesDataContractResolver()
+            };
+
+            using (var ms = new MemoryStream(value))
+            {
+                using (var zipped = new GZipStream(ms, CompressionMode.Decompress))
+                {
+                    using (var sr = new StreamReader(zipped))
+                    {
+                        return (IContainSagaData)serializer.Deserialize(sr, sagaType);
+                    }
+                }
+            }
+        }
+
+        private class SagaOnlyPropertiesDataContractResolver : DefaultContractResolver
+        {
+            public SagaOnlyPropertiesDataContractResolver() : base(true) // for performance
+            {
+            }
+
+            protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+            {
+                var properties = new HashSet<string>(AzureSagaPersister.SelectPropertiesToPersist(type).Select(pi => pi.Name));
+                return base.CreateProperties(type, memberSerialization).Where(p => properties.Contains(p.PropertyName)).ToArray();
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/SecondaryIndeces/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/SecondaryIndeces/SecondaryIndexPersister.cs
@@ -1,0 +1,215 @@
+﻿namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.IO;
+    using System.Linq.Expressions;
+    using System.Net;
+    using System.Reflection;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Table;
+    using Newtonsoft.Json;
+    using NServiceBus.Saga;
+
+    public class SecondaryIndexPersister
+    {
+        readonly Func<Type, CloudTable> getTableForSaga;
+        readonly ScanForSaga scanner;
+        readonly Action<IContainSagaData> persist;
+        
+        const int LRUCapacity = 1000;
+        readonly LRUCache<PartitionRowKeyTuple, Guid> cache = new LRUCache<PartitionRowKeyTuple, Guid>(LRUCapacity);
+
+        public SecondaryIndexPersister(Func<Type, CloudTable> getTableForSaga, ScanForSaga scanner, Action<IContainSagaData> persist)
+        {
+            this.getTableForSaga = getTableForSaga;
+            this.scanner = scanner;
+            this.persist = persist;
+        }
+
+        public delegate Guid? ScanForSaga(Type sagaType, string propertyName, object propertyValue);
+
+        public void Insert(IContainSagaData sagaData)
+        {
+            var sagaType = sagaData.GetType();
+            var table = getTableForSaga(sagaType);
+            var ix = IndexDefintion.Get(sagaType);
+            if (ix == null)
+            {
+                return;
+            }
+
+            var propertyValue = ix.Accessor(sagaData);
+            var key = ix.BuildTableKey(propertyValue);
+
+            var entity = new SecondaryIndexTableEntity
+            {
+                SagaId = sagaData.Id,
+                InitialSagaData = SagaDataSerializer.SerializeSagaData(sagaData),
+                PartitionKey = key.PartitionKey,
+                RowKey = key.RowKey
+            };
+
+            // the insert plan is following:
+            // 1) try insert the 2nd index row
+            // 2) if it fails, another worker has done it
+            // 3) ensure that the primary is stored, throwing an exception afterwards in any way
+
+            try
+            {
+                table.Execute(TableOperation.Insert(entity));
+            }
+            catch (StorageException ex)
+            {
+                var indexRowAlreadyExists = IsConflict(ex);
+                if (indexRowAlreadyExists)
+                {
+                    var indexRow = table.Execute(TableOperation.Retrieve<SecondaryIndexTableEntity>(key.PartitionKey, key.RowKey)).Result as SecondaryIndexTableEntity;
+                    var data = indexRow?.InitialSagaData;
+                    if (data != null)
+                    {
+                        var deserializeSagaData = SagaDataSerializer.DeserializeSagaData(sagaType, data);
+
+                        // saga hasn't been saved under primary key. Try to store it
+                        try
+                        {
+                            persist(deserializeSagaData);
+                        }
+                        catch (StorageException e)
+                        {
+                            if (IsConflict(e))
+                            {
+                                // swallow ex as another worker created the primary under this key
+                            }
+                        }
+                    }
+
+                    throw new RetryNeededException();
+                }
+
+                throw;
+            }
+        }
+
+        public Guid? FindPossiblyCreatingIndexEntry<TSagaData>(string propertyName, object propertyValue)
+            where TSagaData : IContainSagaData
+        {
+            var sagaType = typeof(TSagaData);
+            var ix = IndexDefintion.Get(sagaType);
+            if (ix == null)
+            {
+                throw new ArgumentException($"Saga {typeof(TSagaData)} has no correlation properties. Ensure that your saga is correlated by this property and only then, mark it with `Unique` attribute.");
+            }
+
+            ix.ValidateProperty(propertyName);
+
+            var key = ix.BuildTableKey(propertyValue);
+
+            Guid guid;
+            if (cache.TryGet(key, out guid))
+            {
+                return guid;
+            }
+
+            var table = getTableForSaga(sagaType);
+            var secondaryIndexEntry = table.Execute(TableOperation.Retrieve<SecondaryIndexTableEntity>(key.PartitionKey, key.RowKey)).Result as SecondaryIndexTableEntity;
+            if (secondaryIndexEntry != null)
+            {
+                cache.Put(key, secondaryIndexEntry.SagaId);
+                return secondaryIndexEntry.SagaId;
+            }
+
+            var sagaId = scanner(sagaType, propertyName, propertyValue);
+            if (sagaId == null)
+            {
+                return null;
+            }
+
+            var entity = new SecondaryIndexTableEntity();
+            key.Apply(entity);
+            entity.SagaId = sagaId.Value;
+
+            try
+            {
+                table.Execute(TableOperation.Insert(entity));
+            }
+            catch (StorageException)
+            {
+                throw new RetryNeededException();
+            }
+
+            cache.Put(key, sagaId.Value);
+            return sagaId;
+        }
+
+        private static bool IsConflict(StorageException ex)
+        {
+            return ex.RequestInformation.HttpStatusCode == (int) HttpStatusCode.Conflict;
+        }
+
+        private class IndexDefintion
+        {
+            static readonly ConcurrentDictionary<Type, object> sagaToIndex = new ConcurrentDictionary<Type, object>();
+            static readonly object NullValue = new object();
+
+            static readonly ParameterExpression ObjectParameter = Expression.Parameter(typeof(object));
+
+            readonly string sagaTypeName;
+            readonly string propertyName;
+
+            public Func<object, object> Accessor { get; }
+
+            private IndexDefintion(Type sagaType, PropertyInfo pi)
+            {
+                sagaTypeName = sagaType.FullName;
+                propertyName = pi.Name;
+                Accessor = Expression.Lambda<Func<object, object>>(Expression.Convert(Expression.MakeMemberAccess(Expression.Convert(ObjectParameter, sagaType), pi), typeof(object)), ObjectParameter).Compile();
+            }
+
+            public static IndexDefintion Get(Type sagaType)
+            {
+                var index = sagaToIndex.GetOrAdd(sagaType, type =>
+                {
+                    var pi = UniqueAttribute.GetUniqueProperty(sagaType);
+                    if (pi == null)
+                    {
+                        return NullValue;
+                    }
+
+                    return new IndexDefintion(sagaType, pi);
+                });
+
+                if (ReferenceEquals(index, NullValue))
+                {
+                    return null;
+                }
+
+                return (IndexDefintion) index;
+            }
+
+            public void ValidateProperty(string propertyName)
+            {
+                if (this.propertyName != propertyName)
+                {
+                    throw new ArgumentException($"The following saga '{sagaTypeName} is not indexed by '{propertyName}'. The only secondary index is defined for '{this.propertyName}'. " +
+                                                $"Ensure that the saga is correlated properly.");
+                }
+            }
+
+            public PartitionRowKeyTuple BuildTableKey(object propertyValue)
+            {
+                return new PartitionRowKeyTuple($"Index_{sagaTypeName}", $"{propertyName}_{Serialize(propertyValue)}");
+            }
+
+            private static string Serialize(object propertyValue)
+            {
+                using (var sw = new StringWriter())
+                {
+                    new JsonSerializer().Serialize(sw, propertyValue);
+                    sw.Flush();
+                    return sw.ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Azure/SagaPersisters/SecondaryIndeces/SecondaryIndexTableEntity.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/SecondaryIndeces/SecondaryIndexTableEntity.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System;
+    using Microsoft.WindowsAzure.Storage.Table;
+
+    /// <summary>
+    /// An entity holding information about the secondary index.
+    /// </summary>
+    public class SecondaryIndexTableEntity : TableEntity
+    {
+        public Guid SagaId { get; set; }
+
+        public byte[] InitialSagaData { get; set; }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/Sagas/When_saga_is_started_by_two_types_of_messages.cs
+++ b/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/Sagas/When_saga_is_started_by_two_types_of_messages.cs
@@ -1,0 +1,156 @@
+﻿namespace NServiceBus.AzureStoragePersistence.AcceptanceTests.Sagas
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NServiceBus.Config.ConfigurationSource;
+    using NServiceBus.Saga;
+    using NServiceBus.SagaPersisters.Azure;
+    using NUnit.Framework;
+
+    public class When_saga_is_started_by_two_types_of_messages : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Every_saga_should_be_started_once_and_updated_by_second_message()
+        {
+            const int expectedNumberOfCreatedSagas = 20;
+
+            var guids = new HashSet<string>(Enumerable.Repeat(1, expectedNumberOfCreatedSagas).Select(i => Guid.NewGuid().ToString())).OrderBy(s => s);
+
+            var context = new Context();
+            Scenario.Define(context)
+                    .WithEndpoint<ReceiverWithSagas>(b => b.Given((bus, c) =>
+                    {
+                        foreach (var guid in guids)
+                        {
+                            bus.SendLocal(new OrderBilled
+                            {
+                                OrderId = guid
+                            });
+                            bus.SendLocal(new OrderPlaced
+                            {
+                                OrderId = guid
+                            });
+                        }
+                    }))
+                    .AllowExceptions()
+                    .Done(c => c.CompletedIds.OrderBy(s => s).ToArray().Intersect(guids).Count() == expectedNumberOfCreatedSagas)
+                    .Run();
+
+            CollectionAssert.AreEquivalent(guids, context.CompletedIds.OrderBy(s => s).ToArray());
+
+            var retries = AllIndexesOf(context.Exceptions, typeof(RetryNeededException).FullName).Count();
+            Console.WriteLine($"Sagas with retries/Total no of sagas {retries}/{expectedNumberOfCreatedSagas}");
+        }
+
+        private static IEnumerable<int> AllIndexesOf(string str, string value)
+        {
+            for (int index = 0; ; index += value.Length)
+            {
+                index = str.IndexOf(value, index, StringComparison.Ordinal);
+                if (index == -1)
+                    yield break;
+                yield return index;
+            }
+        }
+
+        public class ProvideConfiguration : IProvideConfiguration<TransportConfig>
+        {
+            public TransportConfig GetConfiguration()
+            {
+                return new TransportConfig
+                {
+                    MaximumConcurrencyLevel = 3,
+                };
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            private readonly ConcurrentDictionary<string, string> completed = new ConcurrentDictionary<string, string>();
+            public int CompletedIdsCount => completed.Count;
+            public IEnumerable<string> CompletedIds => completed.Keys;
+
+            public void MarkAsCompleted(string orderId)
+            {
+                completed.AddOrUpdate(orderId, orderId, (o1, o2) => o1);
+            }
+        }
+
+        public class ReceiverWithSagas : EndpointConfigurationBuilder
+        {
+            public ReceiverWithSagas()
+            {
+                EndpointSetup<DefaultServer>(
+                    config =>
+                    { });
+            }
+        }
+
+        public class ShippingPolicy : Saga<ShippingPolicy.State>,
+            IAmStartedByMessages<OrderPlaced>,
+            IAmStartedByMessages<OrderBilled>
+        {
+            public Context Context { get; set; }
+
+            public void Handle(OrderBilled message)
+            {
+                Data.OrderId = message.OrderId;
+                Data.Billed = true;
+
+                TryComplete();
+            }
+
+            public void Handle(OrderPlaced message)
+            {
+                Data.OrderId = message.OrderId;
+                Data.Placed = true;
+
+                TryComplete();
+            }
+
+            private void TryComplete()
+            {
+                if (Data.Billed && Data.Placed)
+                {
+                    MarkAsComplete();
+                    Context.MarkAsCompleted(Data.OrderId);
+                }
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<State> mapper)
+            {
+                mapper.ConfigureMapping<OrderPlaced>(m => m.OrderId)
+                    .ToSaga(s => s.OrderId);
+                mapper.ConfigureMapping<OrderBilled>(m => m.OrderId)
+                    .ToSaga(s => s.OrderId);
+            }
+
+            public class State : IContainSagaData
+            {
+                [Unique]
+                public virtual string OrderId { get; set; }
+                public virtual bool Placed { get; set; }
+                public virtual bool Billed { get; set; }
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+            }
+        }
+
+        public class OrderBilled : ICommand
+        {
+            public string OrderId { get; set; }
+        }
+
+        public class OrderPlaced : ICommand
+        {
+            public string OrderId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence.Tests/Timeouts/When_removing_timeouts_from_the_storage.cs
+++ b/src/NServiceBus.AzureStoragePersistence.Tests/Timeouts/When_removing_timeouts_from_the_storage.cs
@@ -1,163 +1,171 @@
-﻿﻿namespace NServiceBus.AzureStoragePersistence.Tests.Timeouts
- {
-     using System;
-     using System.Collections.Generic;
-     using System.Linq;
-     using System.Threading.Tasks;
-     using NServiceBus.Timeout.Core;
-     using NUnit.Framework;
+﻿namespace NServiceBus.AzureStoragePersistence.Tests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Timeout.Core;
 
-     [TestFixture]
-     [Category("AzureStoragePersistence")]
-     public class When_removing_timeouts_from_the_storage
-     {
-         [SetUp]
-         public void Perform_storage_cleanup()
-         {
-             TestHelper.PerformStorageCleanup();
-         }
+    [TestFixture]
+    [Category("AzureStoragePersistence")]
+    public class When_removing_timeouts_from_the_storage
+    {
+        [SetUp]
+        public void Perform_storage_cleanup()
+        {
+            TestHelper.PerformStorageCleanup();
+        }
 
-         [Test]
-         public void Should_return_correct_headers_when_timeout_is_TryRemoved()
-         {
-             var timeoutPersister = TestHelper.CreateTimeoutPersister();
+        [Test]
+        public void Should_return_correct_headers_when_timeout_is_TryRemoved()
+        {
+            var timeoutPersister = TestHelper.CreateTimeoutPersister();
 
-             var timeout = TestHelper.GenerateTimeoutWithHeaders();
-             timeoutPersister.Add(timeout);
+            var timeout = TestHelper.GenerateTimeoutWithHeaders();
+            timeoutPersister.Add(timeout);
 
-             var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
+            var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
 
-             Assert.True(timeouts.Count == 1);
+            Assert.True(timeouts.Count == 1);
 
-             TimeoutData timeoutData;
-             timeoutPersister.TryRemove(timeouts.First().Item1, out timeoutData);
+            TimeoutData timeoutData;
+            timeoutPersister.TryRemove(timeouts.First().Item1, out timeoutData);
 
-             CollectionAssert.AreEqual(new Dictionary<string, string> { { "Prop1", "1234" }, { "Prop2", "text" } }, timeoutData.Headers);
-         }
+            CollectionAssert.AreEqual(new Dictionary<string, string>
+            {
+                {"Prop1", "1234"},
+                {"Prop2", "text"}
+            }, timeoutData.Headers);
+        }
 
-         [Test]
-         public void Should_return_correct_headers_when_timeout_is_Peeked()
-         {
-             var timeoutPersister = TestHelper.CreateTimeoutPersister();
+        [Test]
+        public void Should_return_correct_headers_when_timeout_is_Peeked()
+        {
+            var timeoutPersister = TestHelper.CreateTimeoutPersister();
 
-             var timeout = TestHelper.GenerateTimeoutWithHeaders();
-             timeoutPersister.Add(timeout);
+            var timeout = TestHelper.GenerateTimeoutWithHeaders();
+            timeoutPersister.Add(timeout);
 
-             var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
+            var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
 
-             Assert.True(timeouts.Count == 1);
+            Assert.True(timeouts.Count == 1);
 
-             var timeoutId = timeouts.First().Item1;
-             var timeoutData = timeoutPersister.Peek(timeoutId);
+            var timeoutId = timeouts.First().Item1;
+            var timeoutData = timeoutPersister.Peek(timeoutId);
 
-             CollectionAssert.AreEqual(new Dictionary<string, string> { { "Prop1", "1234" }, { "Prop2", "text" } }, timeoutData.Headers);
-         }
+            CollectionAssert.AreEqual(new Dictionary<string, string>
+            {
+                {"Prop1", "1234"},
+                {"Prop2", "text"}
+            }, timeoutData.Headers);
+        }
 
-         [Test]
-         public void Peek_should_return_null_for_non_existing_timeout()
-         {
-             var timeoutPersister = TestHelper.CreateTimeoutPersister();
+        [Test]
+        public void Peek_should_return_null_for_non_existing_timeout()
+        {
+            var timeoutPersister = TestHelper.CreateTimeoutPersister();
 
-             var timeoutData = timeoutPersister.Peek("A2B34534324F3435A324234C");
+            var timeoutData = timeoutPersister.Peek("A2B34534324F3435A324234C");
 
-             Assert.IsNull(timeoutData);
-         }
+            Assert.IsNull(timeoutData);
+        }
 
-         [Test]
-         public void Should_remove_timeouts_by_id_using_old_interface()
-         {
-             var timeoutPersister = TestHelper.CreateTimeoutPersister();
-             var timeout1 = TestHelper.GenerateTimeoutWithHeaders();
-             var timeout2 = TestHelper.GenerateTimeoutWithHeaders();
-             timeoutPersister.Add(timeout1);
-             timeoutPersister.Add(timeout2);
+        [Test]
+        public void Should_remove_timeouts_by_id_using_old_interface()
+        {
+            var timeoutPersister = TestHelper.CreateTimeoutPersister();
+            var timeout1 = TestHelper.GenerateTimeoutWithHeaders();
+            var timeout2 = TestHelper.GenerateTimeoutWithHeaders();
+            timeoutPersister.Add(timeout1);
+            timeoutPersister.Add(timeout2);
 
-             var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
-             Assert.IsTrue(timeouts.Count == 2);
+            var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
+            Assert.IsTrue(timeouts.Count == 2);
 
-             foreach (var timeout in timeouts)
-             {
-                 TimeoutData timeoutData;
-                 timeoutPersister.TryRemove(timeout.Item1, out timeoutData);
-             }
+            foreach (var timeout in timeouts)
+            {
+                TimeoutData timeoutData;
+                timeoutPersister.TryRemove(timeout.Item1, out timeoutData);
+            }
 
-             TestHelper.AssertAllTimeoutsThatHaveBeenRemoved(timeoutPersister);
-         }
+            TestHelper.AssertAllTimeoutsThatHaveBeenRemoved(timeoutPersister);
+        }
 
-         [Test]
-         public void Should_remove_timeouts_by_id_and_return_true_using_new_interface()
-         {
-             var timeoutPersister = TestHelper.CreateTimeoutPersister();
-             var timeout1 = TestHelper.GenerateTimeoutWithHeaders();
-             var timeout2 = TestHelper.GenerateTimeoutWithHeaders();
-             timeoutPersister.Add(timeout1);
-             timeoutPersister.Add(timeout2);
+        [Test]
+        public void Should_remove_timeouts_by_id_and_return_true_using_new_interface()
+        {
+            var timeoutPersister = TestHelper.CreateTimeoutPersister();
+            var timeout1 = TestHelper.GenerateTimeoutWithHeaders();
+            var timeout2 = TestHelper.GenerateTimeoutWithHeaders();
+            timeoutPersister.Add(timeout1);
+            timeoutPersister.Add(timeout2);
 
-             var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
-             Assert.IsTrue(timeouts.Count == 2);
+            var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
+            Assert.IsTrue(timeouts.Count == 2);
 
-             var itemRemoved = true;
-             foreach (var timeout in timeouts)
-             {
-                 itemRemoved &= timeoutPersister.TryRemove(timeout.Item1);
-             }
+            var itemRemoved = true;
+            foreach (var timeout in timeouts)
+            {
+                itemRemoved &= timeoutPersister.TryRemove(timeout.Item1);
+            }
 
-             Assert.IsTrue(itemRemoved, "Expected 2 ivocations to return true, but one or both of them returned false");
+            Assert.IsTrue(itemRemoved, "Expected 2 ivocations to return true, but one or both of them returned false");
 
-             TestHelper.AssertAllTimeoutsThatHaveBeenRemoved(timeoutPersister);
-         }
+            TestHelper.AssertAllTimeoutsThatHaveBeenRemoved(timeoutPersister);
+        }
 
-         [Test]
-         public void Should_return_false_if_timeout_already_deleted_for_TryRemove_invocation()
-         {
-             var timeoutPersister = TestHelper.CreateTimeoutPersister();
+        [Test]
+        public void Should_return_false_if_timeout_already_deleted_for_TryRemove_invocation()
+        {
+            var timeoutPersister = TestHelper.CreateTimeoutPersister();
 
-             var timeout = TestHelper.GenerateTimeoutWithHeaders();
-             timeoutPersister.Add(timeout);
+            var timeout = TestHelper.GenerateTimeoutWithHeaders();
+            timeoutPersister.Add(timeout);
 
-             var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
-             Assert.IsTrue(timeouts.Count == 1);
+            var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
+            Assert.IsTrue(timeouts.Count == 1);
 
-             var timeoutId = timeouts.First().Item1;
+            var timeoutId = timeouts.First().Item1;
 
-             Assert.IsTrue(timeoutPersister.TryRemove(timeoutId));
-             Assert.IsFalse(timeoutPersister.TryRemove(timeoutId));
-         }
+            Assert.IsTrue(timeoutPersister.TryRemove(timeoutId));
+            Assert.IsFalse(timeoutPersister.TryRemove(timeoutId));
+        }
 
-         [Test]
-         public void Should_remove_timeouts_by_sagaid()
-         {
-             var timeoutPersister = TestHelper.CreateTimeoutPersister();
-             var sagaId1 = Guid.NewGuid();
-             var sagaId2 = Guid.NewGuid();
-             var timeout1 = TestHelper.GetnerateTimeoutWithSagaId(sagaId1);
-             var timeout2 = TestHelper.GetnerateTimeoutWithSagaId(sagaId2);
-             timeoutPersister.Add(timeout1);
-             timeoutPersister.Add(timeout2);
+        [Test]
+        public void Should_remove_timeouts_by_sagaid()
+        {
+            var timeoutPersister = TestHelper.CreateTimeoutPersister();
+            var sagaId1 = Guid.NewGuid();
+            var sagaId2 = Guid.NewGuid();
+            var timeout1 = TestHelper.GetnerateTimeoutWithSagaId(sagaId1);
+            var timeout2 = TestHelper.GetnerateTimeoutWithSagaId(sagaId2);
+            timeoutPersister.Add(timeout1);
+            timeoutPersister.Add(timeout2);
 
-             var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
-             Assert.IsTrue(timeouts.Count == 2);
+            var timeouts = TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
+            Assert.IsTrue(timeouts.Count == 2);
 
-             timeoutPersister.RemoveTimeoutBy(sagaId1);
-             timeoutPersister.RemoveTimeoutBy(sagaId2);
+            timeoutPersister.RemoveTimeoutBy(sagaId1);
+            timeoutPersister.RemoveTimeoutBy(sagaId2);
 
-             TestHelper.AssertAllTimeoutsThatHaveBeenRemoved(timeoutPersister);
-         }
+            TestHelper.AssertAllTimeoutsThatHaveBeenRemoved(timeoutPersister);
+        }
 
-         [Test]
-         public async Task TryRemove_should_work_with_concurrent_operations()
-         {
-             var timeoutPersister = TestHelper.CreateTimeoutPersister();
-             var timeout = TestHelper.GenerateTimeoutWithHeaders();
-             timeoutPersister.Add(timeout);
+        [Test]
+        public async Task TryRemove_should_work_with_concurrent_operations()
+        {
+            var timeoutPersister = TestHelper.CreateTimeoutPersister();
+            var timeout = TestHelper.GenerateTimeoutWithHeaders();
+            timeoutPersister.Add(timeout);
 
-             var task1 = Task.Run(() => timeoutPersister.TryRemove(timeout.Id));
-             var task2 = Task.Run(() => timeoutPersister.TryRemove(timeout.Id));
+            var task1 = Task.Run(() => timeoutPersister.TryRemove(timeout.Id));
+            var task2 = Task.Run(() => timeoutPersister.TryRemove(timeout.Id));
 
-             await Task.WhenAll(task1, task2).ConfigureAwait(false);
+            await Task.WhenAll(task1, task2).ConfigureAwait(false);
 
-             Assert.IsTrue(task1.Result || task2.Result);
-             Assert.IsFalse(task1.Result && task2.Result);
-         }
-     }
- }
+            Assert.IsTrue(task1.Result || task2.Result);
+            Assert.IsFalse(task1.Result && task2.Result);
+        }
+    }
+}


### PR DESCRIPTION
This is a backport of Particular/NServiceBus.AzureStoragePersistence#32
Connects to Particular/PlatformDevelopment#634

---
Supersedes #276 
It's properly targeted at `master`