### PR TITLE
Prevent cleanup overlap

### DIFF
--- a/src/NServiceBus.Azure/Config/AzureDataBusConfig.cs
+++ b/src/NServiceBus.Azure/Config/AzureDataBusConfig.cs
@@ -30,6 +30,9 @@ namespace NServiceBus.Config
 
             Properties.Add(new ConfigurationProperty("DefaultTTL", typeof(long), AzureDataBusDefaults.DefaultTTL,
                 null, new CallbackValidator(typeof(long), AzureDataBusGuard.CheckDefaultTTL), ConfigurationPropertyOptions.None));
+
+            Properties.Add(new ConfigurationProperty("CleanupInterval", typeof(int), AzureDataBusDefaults.DefaultCleanupInterval,
+               null, new CallbackValidator(typeof(int), AzureDataBusGuard.CheckCleanupInterval), ConfigurationPropertyOptions.None));
         }
 
         public int MaxRetries
@@ -125,6 +128,18 @@ namespace NServiceBus.Config
             set
             {
                 this["DefaultTTL"] = value;
+            }
+        }
+
+        public int CleanupInterval
+        {
+            get
+            {
+                return (int)this["CleanupInterval"];
+            }
+            set
+            {
+                this["CleanupInterval"] = value;
             }
         }
     }

--- a/src/NServiceBus.Azure/DataBus/Azure/BlobStorage/BlobStorageDataBus.cs
+++ b/src/NServiceBus.Azure/DataBus/Azure/BlobStorage/BlobStorageDataBus.cs
@@ -23,6 +23,7 @@ namespace NServiceBus.DataBus.Azure.BlobStorage
         public string BasePath { get; set; }
         public int BlockSize { get; set; }
         public long DefaultTTL { get; set; }
+        public int CleanupInterval { get; set; }
 
         public BlobStorageDataBus(CloudBlobContainer container)
         {
@@ -50,7 +51,7 @@ namespace NServiceBus.DataBus.Azure.BlobStorage
         {
             ServicePointManager.DefaultConnectionLimit = NumberOfIOThreads;
             container.CreateIfNotExists();
-            timer.Change(0, 300000);
+            if(CleanupInterval > 0) timer.Change(CleanupInterval, Timeout.Infinite);
             logger.Info("Blob storage data bus started. Location: " + BasePath);
         }
 
@@ -83,6 +84,11 @@ namespace NServiceBus.DataBus.Azure.BlobStorage
             catch (StorageException ex) // needs to stay as it runs on a background thread
             {
                 logger.Warn(ex.Message);
+            }
+            finally
+            {
+                // start timer again when done.
+                timer.Change(CleanupInterval, Timeout.Infinite);
             }
         }
 

--- a/src/NServiceBus.Azure/DataBus/AzureDataBusDefaults.cs
+++ b/src/NServiceBus.Azure/DataBus/AzureDataBusDefaults.cs
@@ -12,5 +12,6 @@ namespace NServiceBus
         public const int DefaultBlockSize = 4 * 1024 * 1024; // Maximum 4MB
         public const int DefaultBackOffInterval = 30; // seconds
         public const long DefaultTTL = Int64.MaxValue; // seconds
+        public const int DefaultCleanupInterval = 300000; // milli seconds
     }
 }

--- a/src/NServiceBus.Azure/DataBus/AzureDataBusGuard.cs
+++ b/src/NServiceBus.Azure/DataBus/AzureDataBusGuard.cs
@@ -74,5 +74,13 @@ namespace NServiceBus.DataBus
                 throw new ArgumentOutOfRangeException("defaultTTL", defaultTTL, "DefaultTTL should not be negative.");
             }            
         }
+
+        public static void CheckCleanupInterval(object cleanupInterval)
+        {
+            if ((int)cleanupInterval < 0)
+            {
+                throw new ArgumentOutOfRangeException("cleanupInterval", cleanupInterval, "CleanupInterval should not be negative.");
+            }
+        }
     }
 }

--- a/src/NServiceBus.Azure/DataBus/AzureDataBusPersistence.cs
+++ b/src/NServiceBus.Azure/DataBus/AzureDataBusPersistence.cs
@@ -31,6 +31,7 @@ namespace NServiceBus
                 s.SetDefault("AzureDataBus.NumberOfIOThreads", configSection.NumberOfIOThreads);
                 s.SetDefault("AzureDataBus.BlockSize", configSection.BlockSize);
                 s.SetDefault("AzureDataBus.DefaultTTL", configSection.DefaultTTL);
+                s.SetDefault("AzureDataBus.CleanupInterval", configSection.CleanupInterval);
             });
         }
 
@@ -48,7 +49,8 @@ namespace NServiceBus
                 BackOffInterval = context.Settings.Get<int>("AzureDataBus.BackOffInterval"),
                 NumberOfIOThreads = context.Settings.Get<int>("AzureDataBus.NumberOfIOThreads"),
                 BlockSize = context.Settings.Get<int>("AzureDataBus.BlockSize"),
-                DefaultTTL = context.Settings.Get<long>("AzureDataBus.DefaultTTL")
+                DefaultTTL = context.Settings.Get<long>("AzureDataBus.DefaultTTL"),
+                CleanupInterval = context.Settings.Get<int>("AzureDataBus.CleanupInterval")
             };
 
             context.Container.RegisterSingleton<IDataBus>(dataBus);

--- a/src/NServiceBus.Azure/DataBus/ConfigureAzureDataBus.cs
+++ b/src/NServiceBus.Azure/DataBus/ConfigureAzureDataBus.cs
@@ -67,5 +67,13 @@
             config.GetSettings().Set("AzureDataBus.DefaultTTL", defaultTTLInSeconds);
             return config;
         }
+
+        public static DataBusExtentions<AzureDataBus> CleanupInterval(this DataBusExtentions<AzureDataBus> config, int cleanupInterval)
+        {
+            AzureDataBusGuard.CheckCleanupInterval(cleanupInterval);
+
+            config.GetSettings().Set("AzureDataBus.CleanupInterval", cleanupInterval);
+            return config;
+        }
     }
 }

--- a/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
@@ -9,7 +9,6 @@
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Table;
     using Newtonsoft.Json;
-    using NServiceBus.Sagas;
     using Saga;
 
     public class SecondaryIndexPersister


### PR DESCRIPTION
## Who's affected

Anyone using Azure DataBus and experiencing situations when endpoints stop processing messages

## Symptoms

Large amount of Azure Blobs can cause an overlapping cleanup logic execution which would lead to resources exhaustion, causing endpoint stop processing messages.

## Workaround

Restarting endpoints will relieve resources pressure and allow endpoints to continue processing messages.  Optionally, in addition to restart, a manual clean up of the expired blobs can be performed.

## Changes

- Configurable interval (`0` to disable cleanup)
- Change to timer interval settings so that no overlap can happen