### PR TITLE
Poor exception handling in Cleanup

### DIFF
--- a/src/NServiceBus.Azure/DataBus/Azure/BlobStorage/BlobStorageDataBus.cs
+++ b/src/NServiceBus.Azure/DataBus/Azure/BlobStorage/BlobStorageDataBus.cs
@@ -82,10 +82,10 @@ namespace NServiceBus.DataBus.Azure.BlobStorage
                             blockBlob.DeleteIfExists();
                         }
                     }
-                    // ReSharper disable once EmptyGeneralCatchClause
-                    catch
+                    catch(Exception ex)
                     {
                         // Another endpoint instance could have deleted the blob just a moment ago after blobs were listed by the current instance
+                        logger.WarnFormat($"{nameof(BlobStorageDataBus)} has encountered an exception while deleting blob {blockBlob.Name}.", ex);
                     }
                 }
             }

--- a/src/NServiceBus.Azure/DataBus/Azure/BlobStorage/BlobStorageDataBus.cs
+++ b/src/NServiceBus.Azure/DataBus/Azure/BlobStorage/BlobStorageDataBus.cs
@@ -73,17 +73,25 @@ namespace NServiceBus.DataBus.Azure.BlobStorage
                 {
                     if (blockBlob == null) continue;
 
-                    blockBlob.FetchAttributes();
-                    var validUntil = GetValidUntil(blockBlob, DefaultTTL);
-                    if (validUntil < DateTime.UtcNow)
+                    try
                     {
-                        blockBlob.DeleteIfExists();
+                        blockBlob.FetchAttributes();
+                        var validUntil = GetValidUntil(blockBlob, DefaultTTL);
+                        if (validUntil < DateTime.UtcNow)
+                        {
+                            blockBlob.DeleteIfExists();
+                        }
+                    }
+                    // ReSharper disable once EmptyGeneralCatchClause
+                    catch
+                    {
+                        // Another endpoint instance could have deleted the blob just a moment ago after blobs were listed by the current instance
                     }
                 }
             }
             catch (StorageException ex) // needs to stay as it runs on a background thread
             {
-                logger.Warn(ex.Message);
+                logger.WarnFormat($"{nameof(BlobStorageDataBus)} has encountered an exception.", ex);
             }
             finally
             {

--- a/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.Azure/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
@@ -9,7 +9,6 @@
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Table;
     using Newtonsoft.Json;
-    using NServiceBus.Sagas;
     using Saga;
 
     public class SecondaryIndexPersister


### PR DESCRIPTION
## Who's affected

Anyone using Azure DataBus and scaled out endpoints 

## Symptoms

Scaled out endpoint could attempt to remove blobs in parallel. This could result in instances listing blobs that are removed by another instance. When attempt is made to remove a blob that doesn't exist, exception is thrown and `foreach` loop will be interrupted, causing to skip the rest of the blobs that potentially could be deleted.

## Workaround

Not required. Eventually blobs are removed by the last endpoint instance.